### PR TITLE
Upgrade to latest fleet:v4.64.2

### DIFF
--- a/addons/vuln-processing/variables.tf
+++ b/addons/vuln-processing/variables.tf
@@ -24,7 +24,7 @@ variable "fleet_config" {
     vuln_processing_cpu                  = optional(number, 2048)
     vuln_data_stream_mem                 = optional(number, 1024)
     vuln_data_stream_cpu                 = optional(number, 512)
-    image                                = optional(string, "fleetdm/fleet:v4.64.1")
+    image                                = optional(string, "fleetdm/fleet:v4.64.2")
     family                               = optional(string, "fleet-vuln-processing")
     sidecars                             = optional(list(any), [])
     extra_environment_variables          = optional(map(string), {})
@@ -82,7 +82,7 @@ variable "fleet_config" {
     vuln_processing_cpu                  = 2048
     vuln_data_stream_mem                 = 1024
     vuln_data_stream_cpu                 = 512
-    image                                = "fleetdm/fleet:v4.64.1"
+    image                                = "fleetdm/fleet:v4.64.2"
     family                               = "fleet-vuln-processing"
     sidecars                             = []
     extra_environment_variables          = {}

--- a/byo-vpc/byo-db/byo-ecs/variables.tf
+++ b/byo-vpc/byo-db/byo-ecs/variables.tf
@@ -16,7 +16,7 @@ variable "fleet_config" {
     mem                          = optional(number, 4096)
     cpu                          = optional(number, 512)
     pid_mode                     = optional(string, null)
-    image                        = optional(string, "fleetdm/fleet:v4.64.1")
+    image                        = optional(string, "fleetdm/fleet:v4.64.2")
     family                       = optional(string, "fleet")
     sidecars                     = optional(list(any), [])
     depends_on                   = optional(list(any), [])
@@ -123,7 +123,7 @@ variable "fleet_config" {
     mem                          = 512
     cpu                          = 256
     pid_mode                     = null
-    image                        = "fleetdm/fleet:v4.64.1"
+    image                        = "fleetdm/fleet:v4.64.2"
     family                       = "fleet"
     sidecars                     = []
     depends_on                   = []

--- a/byo-vpc/byo-db/variables.tf
+++ b/byo-vpc/byo-db/variables.tf
@@ -77,7 +77,7 @@ variable "fleet_config" {
     mem                          = optional(number, 4096)
     cpu                          = optional(number, 512)
     pid_mode                     = optional(string, null)
-    image                        = optional(string, "fleetdm/fleet:v4.64.1")
+    image                        = optional(string, "fleetdm/fleet:v4.64.2")
     family                       = optional(string, "fleet")
     sidecars                     = optional(list(any), [])
     depends_on                   = optional(list(any), [])
@@ -209,7 +209,7 @@ variable "fleet_config" {
     mem                          = 512
     cpu                          = 256
     pid_mode                     = null
-    image                        = "fleetdm/fleet:v4.64.1"
+    image                        = "fleetdm/fleet:v4.64.2"
     family                       = "fleet"
     sidecars                     = []
     depends_on                   = []

--- a/byo-vpc/example/main.tf
+++ b/byo-vpc/example/main.tf
@@ -17,7 +17,7 @@ provider "aws" {
 }
 
 locals {
-  fleet_image = "fleetdm/fleet:v4.64.1"
+  fleet_image = "fleetdm/fleet:v4.64.2"
   domain_name = "example.com"
 }
 

--- a/byo-vpc/variables.tf
+++ b/byo-vpc/variables.tf
@@ -174,7 +174,7 @@ variable "fleet_config" {
     mem                          = optional(number, 4096)
     cpu                          = optional(number, 512)
     pid_mode                     = optional(string, null)
-    image                        = optional(string, "fleetdm/fleet:v4.64.1")
+    image                        = optional(string, "fleetdm/fleet:v4.64.2")
     family                       = optional(string, "fleet")
     sidecars                     = optional(list(any), [])
     depends_on                   = optional(list(any), [])
@@ -306,7 +306,7 @@ variable "fleet_config" {
     mem                          = 512
     cpu                          = 256
     pid_mode                     = null
-    image                        = "fleetdm/fleet:v4.64.1"
+    image                        = "fleetdm/fleet:v4.64.2"
     family                       = "fleet"
     sidecars                     = []
     depends_on                   = []

--- a/example/main.tf
+++ b/example/main.tf
@@ -63,8 +63,8 @@ module "fleet" {
 
   fleet_config = {
     # To avoid pull-rate limiting from dockerhub, consider using our quay.io mirror
-    # for the Fleet image. e.g. "quay.io/fleetdm/fleet:v4.64.1"
-    image = "fleetdm/fleet:v4.64.1" # override default to deploy the image you desire
+    # for the Fleet image. e.g. "quay.io/fleetdm/fleet:v4.64.2"
+    image = "fleetdm/fleet:v4.64.2" # override default to deploy the image you desire
     # See https://fleetdm.com/docs/deploy/reference-architectures#aws for appropriate scaling
     # memory and cpu.
     autoscaling = {

--- a/variables.tf
+++ b/variables.tf
@@ -222,7 +222,7 @@ variable "fleet_config" {
     mem                          = optional(number, 4096)
     cpu                          = optional(number, 512)
     pid_mode                     = optional(string, null)
-    image                        = optional(string, "fleetdm/fleet:v4.64.1")
+    image                        = optional(string, "fleetdm/fleet:v4.64.2")
     family                       = optional(string, "fleet")
     sidecars                     = optional(list(any), [])
     depends_on                   = optional(list(any), [])
@@ -354,7 +354,7 @@ variable "fleet_config" {
     mem                          = 512
     cpu                          = 256
     pid_mode                     = null
-    image                        = "fleetdm/fleet:v4.64.1"
+    image                        = "fleetdm/fleet:v4.64.2"
     family                       = "fleet"
     sidecars                     = []
     depends_on                   = []


### PR DESCRIPTION
Upgrade to latest `fleet:v4.64.2` which fixes `CVE-2025-27509`

cf. https://github.com/fleetdm/fleet/security/advisories/GHSA-52jx-g6m5-h735