### PR TITLE
Fix cron monitor issue when jobs have no errors

### DIFF
--- a/addons/monitoring/lambda/main.go
+++ b/addons/monitoring/lambda/main.go
@@ -55,6 +55,7 @@ type OptionsStruct struct {
 	AWSRegion                  string `long:"aws-region" env:"AWS_REGION" required:"true"`
 	CronDelayTolerance         string `long:"cron-delay-tolerance" env:"CRON_DELAY_TOLERANCE" default:"2h"`
 	CronMonitorInterval        string `long:"monitor-run-interval" env:"CRON_MONITOR_RUN_INTERVAL" default:"1 hour"`
+	AwsEndpointUrl             string `long:"aws-endpoint-url" env:"AWS_ENDPOINT_URL"`
 }
 
 var (
@@ -120,7 +121,7 @@ type CronStatsDigestRow struct {
 	num_occurences    int
 	num_errors        int
 	last_updated_at   time.Time
-	most_recent_error string
+	most_recent_error sql.NullString
 }
 
 func setupDB(sess *session.Session) (db *sql.DB, err error) {
@@ -242,11 +243,11 @@ func checkCrons(db *sql.DB, sess *session.Session) (err error) {
 		if row.num_errors == 0 {
 			continue
 		}
-		log.Printf("*** %s job had errors (runs: %d, errors: %d), alerting! (errors %s)", row.name, row.num_occurences, row.num_errors, row.most_recent_error)
+		log.Printf("*** %s job had errors (runs: %d, errors: %d), alerting! (errors %s)", row.name, row.num_occurences, row.num_errors, row.most_recent_error.String)
 		if row.num_occurences == 1 {
-			sendSNSMessage(fmt.Sprintf("Fleet cron '%s' (last updated %s) raised errors during its last run:\n%s", row.name, row.updated_at.String(), row.errors), "cronJobFailure", sess)
+			sendSNSMessage(fmt.Sprintf("Fleet cron '%s' (last updated %s) raised errors during its last run:\n%s", row.name, row.updated_at.String(), row.most_recent_error.String), "cronJobFailure", sess)
 		} else {
-			sendSNSMessage(fmt.Sprintf("Fleet cron '%s' (last updated %s) raised errors in %d of the previous %d runs; the most recent is:\n%s", row.name, row.last_updated_at.String(), row.num_errors, row.num_occurences, row.most_recent_error), "cronJobFailure", sess)
+			sendSNSMessage(fmt.Sprintf("Fleet cron '%s' (last updated %s) raised errors in %d of the previous %d runs; the most recent is:\n%s", row.name, row.last_updated_at.String(), row.num_errors, row.num_occurences, row.most_recent_error.String), "cronJobFailure", sess)
 		}
 	}
 
@@ -254,12 +255,15 @@ func checkCrons(db *sql.DB, sess *session.Session) (err error) {
 }
 
 func handler(ctx context.Context, name NullEvent) error {
+	awsConfig := aws.NewConfig()
+	awsConfig = awsConfig.WithRegion(options.AWSRegion)
+	if options.AwsEndpointUrl != "" {
+		awsConfig = awsConfig.WithEndpoint(options.AwsEndpointUrl)
+	}
 	sess := session.Must(session.NewSessionWithOptions(
 		session.Options{
 			SharedConfigState: session.SharedConfigEnable,
-			Config: aws.Config{
-				Region: &options.AWSRegion,
-			},
+			Config:            *awsConfig,
 		},
 	))
 

--- a/addons/monitoring/lambda/main.go
+++ b/addons/monitoring/lambda/main.go
@@ -268,7 +268,11 @@ func handler(ctx context.Context, name NullEvent) error {
 	))
 
 	db, err := setupDB(sess)
-	defer db.Close()
+	defer func() {
+		if db != nil {
+			db.Close()
+		}
+	}()
 
 	if err != nil {
 		return nil


### PR DESCRIPTION
# Details

The work to digest the errors reported by the cron monitor introduced a bug where if a job had no errors, it would cause a failure in the monitor.  This was due to the use of a `string` type for a variable connected to a nullable MySQL column.  The fix is to change it to use `sql.nullString`.

Before:

```
2025/04/17 16:11:35 main.go:246: *** apple_mdm_apns_pusher job had errors (runs: 1, errors: 1), alerting! (errors {"foo": "bar"})
2025/04/17 16:11:35 main.go:73: Sending SNS Message
2025/04/17 16:11:35 main.go:77: Sending 'Environment: debug
Message: Fleet cron 'apple_mdm_apns_pusher' (last updated 0001-01-01 00:00:00 +0000 UTC) raised errors during its last run:
{"foo": "bar"}' to 'arn:aws:sns:us-east-1:000000000000:cron-test-topic'
2025/04/17 16:11:35 main.go:85: {
  MessageId: "82c98a1e-9c87-451e-87b3-45192a3a3440"
}
2025/04/17 16:11:35 main.go:239: sql: Scan error on column index 4, name "most_recent_error": converting NULL to string is unsupported
2025/04/17 16:11:35 main.go:73: Sending SNS Message
2025/04/17 16:11:35 main.go:77: Sending 'Environment: debug
Message: Error scanning row in cron_stats table.  Unable to continue.' to 'arn:aws:sns:us-east-1:000000000000:cron-test-topic'
2025/04/17 16:11:35 main.go:85: {
  MessageId: "7dabd4b1-e699-4118-9b14-3b436cfed04c"
}
```

After:
```
2025/04/17 16:15:22 main.go:246: *** apple_mdm_apns_pusher job had errors (runs: 1, errors: 1), alerting! (errors {"foo": "bar"})
2025/04/17 16:15:22 main.go:73: Sending SNS Message
2025/04/17 16:15:22 main.go:77: Sending 'Environment: debug
Message: Fleet cron 'apple_mdm_apns_pusher' (last updated 0001-01-01 00:00:00 +0000 UTC) raised errors during its last run:
{"foo": "bar"}' to 'arn:aws:sns:us-east-1:000000000000:cron-test-topic'
2025/04/17 16:15:22 main.go:85: {
  MessageId: "6142886e-f7d1-47fa-9cb5-313256419faf"
}
```

# Testing

Testing this is a bit of a pain, but other updates in this PR make it slightly better.  First off, you should have a local Fleet instance running for a few minutes accumulate some cron_stats data.  Then:

1. **Turn on `sns` and `secretsmanager` in localstack.**
   1. Edit [this line](https://github.com/fleetdm/fleet/blob/main/docker-compose.yml#L154) in docker-compose.yml in the main Fleet repo, adding `sns,secretsmanager` to the list of services.
   2. Restart the Fleet stack with `docker compose down && docker compose up -d`
1. **Configure localstack and set up required data.** In a terminal, do:
   1. `docker exec fleet-localstack-1 aws configure set aws_access_key_id test`
   2. `docker exec fleet-localstack-1 aws configure set aws_secret_access_key test`
   3. `docker exec fleet-localstack-1 aws configure set default.region us-east-1`
   4. `SM_ARN=$(docker exec fleet-localstack-1 aws secretsmanager create-secret --name mysql --secret-string="toor" --endpoint-url="http://localhost:4566" | jq -r ".ARN")`
   5. `TOPIC_ARN=$(docker exec fleet-localstack-1 aws sns create-topic --name="cron-test-topic" --endpoint-url="http://localhost:4566" | jq -r ".TopicArn")`
1. **Alias the test command:** `alias test-cron='AWS_ACCESS_KEY_ID=test AWS_SECRET_ACCESS_KEY=test CRON_SYSTEM_MONITOR_SNS_TOPIC_ARNS=$TOPIC_ARN  MYSQL_HOST=localhost MYSQL_USER=root MYSQL_SECRETSMANAGER_SECRET=$SM_ARN MYSQL_DATABASE=fleet FLEET_ENV=debug AWS_REGION=us-east-1 AWS_DEFAULT_REGION=us-east-1 AWS_ENDPOINT_URL=http://localhost:4566 go run .'`
1. **Test with no errors.** There should be no errors in any of your local cron jobs, so we can test that the monitor works in that case.
   1. `cd /path/to/fleet-terraform/addons/monitoring/lambda`
   2. `test-cron`
   3. There should be no output pertaining to cron job errors.
1. **Add errors to some cron jobs** and test again:
   1. `docker exec fleet-mysql-1 bash -c "echo \"update cron_stats set errors='{\\\"owl\\\":\\\"hoot\\\"}' where name=\\\"integrations\\\" and errors is null order by updated_at desc limit 2\" | mysql -u root -ptoor fleet"`
   2. `docker exec fleet-mysql-1 bash -c "echo \"update cron_stats set errors='{\\\"cat\\\":\\\"meow\\\"}' where name=\\\"integrations\\\" and errors is null order by updated_at desc limit 2\" | mysql -u root -ptoor fleet"`
   4. `test-cron`
   5. There should output be similar to:
```
2025/04/17 16:51:51 main.go:246: *** integrations job had errors (runs: 278, errors: 4), alerting! (errors {"cat": "meow"})
2025/04/17 16:51:51 main.go:73: Sending SNS Message
2025/04/17 16:51:51 main.go:77: Sending 'Environment: debug
Message: Fleet cron 'integrations' (last updated 2025-04-17 21:51:49 +0000 UTC) raised errors in 4 of the previous 278 runs; the most recent is:
{"cat": "meow"}' to 'arn:aws:sns:us-east-1:000000000000:cron-test-topic'
2025/04/17 16:51:51 main.go:85: {
  MessageId: "a9a6c478-8f67-4400-9007-5c4b44aeb5af"
}
```   
5. **Add error to a single run of a job** and test:
   7. `docker exec fleet-mysql-1 bash -c "echo \"insert into cron_stats (name, instance, stats_type, status, errors) values ('test-job', 'abc123', 'scheduled', 'completed', '{\\\"dog\\\":\\\"woof\\\"}')\" | mysql -u root -ptoor fleet"`
   8. `test-cron`
   9. There should be output similar to:
```
Message: Fleet cron 'test-job' (last updated 0001-01-01 00:00:00 +0000 UTC) raised errors during its last run:
{"dog": "woof"}' to 'arn:aws:sns:us-east-1:000000000000:cron-test-topic'
2025/04/17 16:59:13 main.go:85: {
  MessageId: "d246bda3-e423-42e4-a9bf-519d16499ae0"
}
```   