### PR TITLE
Adding force destroy = true to software installers bucket resource block

### DIFF
--- a/byo-vpc/byo-db/byo-ecs/main.tf
+++ b/byo-vpc/byo-db/byo-ecs/main.tf
@@ -296,6 +296,9 @@ resource "aws_s3_bucket" "software_installers" { #tfsec:ignore:aws-s3-encryption
   bucket        = var.fleet_config.software_installers.bucket_name
   bucket_prefix = var.fleet_config.software_installers.bucket_prefix
   tags          = var.fleet_config.software_installers.tags
+  
+  # Allow destroy of non-empty buckets
+  force_destroy = true
 }
 
 resource "aws_s3_bucket_versioning" "software_installers" {

--- a/byo-vpc/example/main.tf
+++ b/byo-vpc/example/main.tf
@@ -92,7 +92,7 @@ module "vpc" {
 }
 
 module "byo-vpc" {
-  source = "github.com/fleetdm/fleet-terraform//byo-vpc?depth=1&ref=tf-mod-byo-vpc-v1.17.0"
+  source = "github.com/fleetdm/fleet-terraform//byo-vpc?depth=1&ref=tf-mod-byo-vpc-v1.17.1"
   vpc_config = {
     vpc_id = module.vpc.vpc_id
     networking = {

--- a/example/main.tf
+++ b/example/main.tf
@@ -52,7 +52,7 @@ locals {
 }
 
 module "fleet" {
-  source          = "github.com/fleetdm/fleet-terraform?depth=1&ref=tf-mod-root-v1.15.1"
+  source          = "github.com/fleetdm/fleet-terraform?depth=1&ref=tf-mod-root-v1.15.2"
   certificate_arn = module.acm.acm_certificate_arn
 
   vpc = {


### PR DESCRIPTION
Adding `force_destroy = true` to allow for the removal of software installers bucket when terraform attempts to destroy the s3 bucket.