### PR TITLE
add datadog logging-addon via firehose

### DIFF
--- a/addons/logging-destination-datadog/.header.md
+++ b/addons/logging-destination-datadog/.header.md
@@ -1,0 +1,114 @@
+# Logging Destination: Datadog
+
+This addon configures AWS Kinesis Firehose to send Fleet's osquery logs to Datadog. It creates:
+
+1. Kinesis Firehose delivery streams for each log type (results, status, and audit)
+2. A single S3 bucket for storing all failed delivery attempts
+3. IAM roles and policies for the Firehose streams to access the S3 bucket
+4. An IAM policy for Fleet to access the Firehose streams
+
+## How to use
+
+```hcl
+module "datadog-logging" {
+  source = "github.com/fleetdm/fleet-terraform//addons/logging-destination-datadog?ref=tf-mod-addon-logging-destination-datadog-v1.0.0"
+
+  datadog_api_key = "your-datadog-api-key"
+
+  # Optional: customize other settings
+  # datadog_url = "https://custom-datadog-endpoint.com"
+  # s3_bucket_config = {
+  #   name_prefix = "custom-bucket-prefix"
+  #   expires_days = 7
+  # }
+  # log_destinations = {
+  #   results = {
+  #     name = "custom-results-stream-name"
+  #     buffering_size = 1
+  #     buffering_interval = 60
+  #     s3_buffering_size = 10
+  #     s3_buffering_interval = 400
+  #     common_attributes = [
+  #       {
+  #         name  = "service"
+  #         value = "fleet-osquery-results"
+  #       },
+  #       {
+  #         name  = "environment"
+  #         value = "production"
+  #       }
+  #     ]
+  #   },
+  #   status = {
+  #     name = "custom-status-stream-name"
+  #     buffering_size = 1
+  #     buffering_interval = 60
+  #     s3_buffering_size = 10
+  #     s3_buffering_interval = 400
+  #     common_attributes = [
+  #       {
+  #         name  = "service"
+  #         value = "fleet-osquery-status"
+  #       },
+  #       {
+  #         name  = "environment"
+  #         value = "production"
+  #       }
+  #     ]
+  #   },
+  #   audit = {
+  #     name = "custom-audit-stream-name"
+  #     buffering_size = 1
+  #     buffering_interval = 60
+  #     s3_buffering_size = 10
+  #     s3_buffering_interval = 400
+  #     common_attributes = [
+  #       {
+  #         name  = "service"
+  #         value = "fleet-audit"
+  #       },
+  #       {
+  #         name  = "environment"
+  #         value = "production"
+  #       }
+  #     ]
+  #   }
+  # }
+  # compression_format = "GZIP"
+}
+```
+
+Then you can use the module's outputs in your Fleet configuration:
+
+```hcl
+module "fleet" {
+  source = "github.com/fleetdm/fleet-terraform?depth=1&ref=tf-mod-root-v1.15.2"
+  certificate_arn = module.acm.acm_certificate_arn
+
+  vpc = {
+    name = local.vpc_name
+    # azs = ["us-east-2a", "us-east-2b", "us-east-2c"]
+  }
+
+  fleet_config = {
+    image = "fleetdm/fleet:v4.69.0"
+    autoscaling = {
+      min_capacity = 2
+      max_capacity = 5
+    }
+    mem = 4096
+    cpu = 512
+    extra_environment_variables = merge(
+      local.fleet_environment_variables,
+      # Uncomment to enable Datadog logging
+      module.datadog-logging.fleet_extra_environment_variables
+    )
+    extra_iam_policies = concat(
+      # Uncomment to enable Datadog logging
+      module.datadog-logging.fleet_extra_iam_policies,
+    )
+  }
+
+  # ... other Fleet configuration ...
+}
+```

--- a/addons/logging-destination-datadog/.terraform-docs.yml
+++ b/addons/logging-destination-datadog/.terraform-docs.yml
@@ -1,0 +1,1 @@
+header-from: .header.md

--- a/addons/logging-destination-datadog/README.md
+++ b/addons/logging-destination-datadog/README.md
@@ -1,0 +1,163 @@
+# Logging Destination: Datadog
+
+This addon configures AWS Kinesis Firehose to send Fleet's osquery logs to Datadog. It creates:
+
+1. Kinesis Firehose delivery streams for each log type (results, status, and audit)
+2. A single S3 bucket for storing all failed delivery attempts
+3. IAM roles and policies for the Firehose streams to access the S3 bucket
+4. An IAM policy for Fleet to access the Firehose streams
+
+## How to use
+
+```hcl
+module "datadog-logging" {
+  source = "github.com/fleetdm/fleet-terraform//addons/logging-destination-datadog?ref=tf-mod-addon-logging-destination-datadog-v1.0.0"
+
+  datadog_api_key = "your-datadog-api-key"
+
+  # Optional: customize other settings
+  # datadog_url = "https://custom-datadog-endpoint.com"
+  # s3_bucket_config = {
+  #   name_prefix = "custom-bucket-prefix"
+  #   expires_days = 7
+  # }
+  # log_destinations = {
+  #   results = {
+  #     name = "custom-results-stream-name"
+  #     buffering_size = 1
+  #     buffering_interval = 60
+  #     s3_buffering_size = 10
+  #     s3_buffering_interval = 400
+  #     common_attributes = [
+  #       {
+  #         name  = "service"
+  #         value = "fleet-osquery-results"
+  #       },
+  #       {
+  #         name  = "environment"
+  #         value = "production"
+  #       }
+  #     ]
+  #   },
+  #   status = {
+  #     name = "custom-status-stream-name"
+  #     buffering_size = 1
+  #     buffering_interval = 60
+  #     s3_buffering_size = 10
+  #     s3_buffering_interval = 400
+  #     common_attributes = [
+  #       {
+  #         name  = "service"
+  #         value = "fleet-osquery-status"
+  #       },
+  #       {
+  #         name  = "environment"
+  #         value = "production"
+  #       }
+  #     ]
+  #   },
+  #   audit = {
+  #     name = "custom-audit-stream-name"
+  #     buffering_size = 1
+  #     buffering_interval = 60
+  #     s3_buffering_size = 10
+  #     s3_buffering_interval = 400
+  #     common_attributes = [
+  #       {
+  #         name  = "service"
+  #         value = "fleet-audit"
+  #       },
+  #       {
+  #         name  = "environment"
+  #         value = "production"
+  #       }
+  #     ]
+  #   }
+  # }
+  # compression_format = "GZIP"
+}
+```
+
+Then you can use the module's outputs in your Fleet configuration:
+
+```hcl
+module "fleet" {
+  source = "github.com/fleetdm/fleet-terraform?depth=1&ref=tf-mod-root-v1.15.2"
+  certificate_arn = module.acm.acm_certificate_arn
+
+  vpc = {
+    name = local.vpc_name
+    # azs = ["us-east-2a", "us-east-2b", "us-east-2c"]
+  }
+
+  fleet_config = {
+    image = "fleetdm/fleet:v4.69.0"
+    autoscaling = {
+      min_capacity = 2
+      max_capacity = 5
+    }
+    mem = 4096
+    cpu = 512
+    extra_environment_variables = merge(
+      local.fleet_environment_variables,
+      # Uncomment to enable Datadog logging
+      module.datadog-logging.fleet_extra_environment_variables
+    )
+    extra_iam_policies = concat(
+      # Uncomment to enable Datadog logging
+      module.datadog-logging.fleet_extra_iam_policies,
+    )
+  }
+
+  # ... other Fleet configuration ...
+}
+```
+
+## Requirements
+
+No requirements.
+
+## Providers
+
+| Name | Version |
+|------|---------|
+| <a name="provider_aws"></a> [aws](#provider\_aws) | n/a |
+
+## Modules
+
+No modules.
+
+## Resources
+
+| Name | Type |
+|------|------|
+| [aws_iam_policy.firehose](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_policy) | resource |
+| [aws_iam_policy.firehose-logging](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_policy) | resource |
+| [aws_iam_role.firehose](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role) | resource |
+| [aws_iam_role_policy_attachment.firehose](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy_attachment) | resource |
+| [aws_kinesis_firehose_delivery_stream.datadog](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/kinesis_firehose_delivery_stream) | resource |
+| [aws_s3_bucket.datadog-failure](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket) | resource |
+| [aws_s3_bucket_lifecycle_configuration.datadog-failure](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket_lifecycle_configuration) | resource |
+| [aws_s3_bucket_public_access_block.datadog-failure](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket_public_access_block) | resource |
+| [aws_s3_bucket_server_side_encryption_configuration.datadog-failure](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket_server_side_encryption_configuration) | resource |
+| [aws_iam_policy_document.firehose-logging](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
+| [aws_iam_policy_document.firehose_policy](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
+| [aws_iam_policy_document.osquery_firehose_assume_role](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
+| [aws_region.current](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/region) | data source |
+
+## Inputs
+
+| Name | Description | Type | Default | Required |
+|------|-------------|------|---------|:--------:|
+| <a name="input_compression_format"></a> [compression\_format](#input\_compression\_format) | Compression format for the Firehose delivery stream | `string` | `"GZIP"` | no |
+| <a name="input_datadog_api_key"></a> [datadog\_api\_key](#input\_datadog\_api\_key) | Datadog API key for authentication | `string` | n/a | yes |
+| <a name="input_datadog_url"></a> [datadog\_url](#input\_datadog\_url) | Datadog HTTP API endpoint URL | `string` | `"https://aws-kinesis-http-intake.logs.datadoghq.com/v1/input"` | no |
+| <a name="input_log_destinations"></a> [log\_destinations](#input\_log\_destinations) | A map of configurations for Datadog Firehose delivery streams. | <pre>map(object({<br>    name                  = string<br>    buffering_size        = number<br>    buffering_interval    = number<br>    s3_buffering_size     = number<br>    s3_buffering_interval = number<br>    compression_type      = string<br>    common_attributes = optional(list(object({<br>      name  = string<br>      value = string<br>    })), [])<br>  }))</pre> | <pre>{<br>  "audit": {<br>    "buffering_interval": 60,<br>    "buffering_size": 1,<br>    "common_attributes": [],<br>    "compression_type": "GZIP",<br>    "name": "fleet-audit-datadog",<br>    "s3_buffering_interval": 400,<br>    "s3_buffering_size": 10<br>  },<br>  "results": {<br>    "buffering_interval": 60,<br>    "buffering_size": 1,<br>    "common_attributes": [],<br>    "compression_type": "GZIP",<br>    "name": "fleet-osquery-results-datadog",<br>    "s3_buffering_interval": 400,<br>    "s3_buffering_size": 10<br>  },<br>  "status": {<br>    "buffering_interval": 60,<br>    "buffering_size": 1,<br>    "common_attributes": [],<br>    "compression_type": "GZIP",<br>    "name": "fleet-osquery-status-datadog",<br>    "s3_buffering_interval": 400,<br>    "s3_buffering_size": 10<br>  }<br>}</pre> | no |
+| <a name="input_s3_bucket_config"></a> [s3\_bucket\_config](#input\_s3\_bucket\_config) | Configuration for the S3 bucket used to store failed Datadog delivery attempts | <pre>object({<br>    name_prefix  = optional(string, "fleet-datadog-failure")<br>    expires_days = optional(number, 1)<br>  })</pre> | <pre>{<br>  "expires_days": 1,<br>  "name_prefix": "fleet-datadog-failure"<br>}</pre> | no |
+
+## Outputs
+
+| Name | Description |
+|------|-------------|
+| <a name="output_fleet_extra_environment_variables"></a> [fleet\_extra\_environment\_variables](#output\_fleet\_extra\_environment\_variables) | Environment variables to configure Fleet to use Datadog logging via Firehose |
+| <a name="output_fleet_extra_iam_policies"></a> [fleet\_extra\_iam\_policies](#output\_fleet\_extra\_iam\_policies) | IAM policies required for Fleet to log to Datadog via Firehose |

--- a/addons/logging-destination-datadog/main.tf
+++ b/addons/logging-destination-datadog/main.tf
@@ -1,0 +1,128 @@
+data "aws_region" "current" {}
+
+resource "aws_s3_bucket" "datadog-failure" { #tfsec:ignore:aws-s3-encryption-customer-key:exp:2022-07-01  #tfsec:ignore:aws-s3-enable-versioning #tfsec:ignore:aws-s3-enable-bucket-logging:exp:2022-06-15
+  bucket_prefix = var.s3_bucket_config.name_prefix
+}
+
+resource "aws_s3_bucket_lifecycle_configuration" "datadog-failure" {
+  bucket = aws_s3_bucket.datadog-failure.bucket
+  rule {
+    status = "Enabled"
+    id     = "expire"
+    expiration {
+      days = var.s3_bucket_config.expires_days
+    }
+  }
+}
+
+resource "aws_s3_bucket_server_side_encryption_configuration" "datadog-failure" {
+  bucket = aws_s3_bucket.datadog-failure.bucket
+  rule {
+    apply_server_side_encryption_by_default {
+      sse_algorithm = "aws:kms"
+    }
+  }
+}
+
+resource "aws_s3_bucket_public_access_block" "datadog-failure" {
+  bucket                  = aws_s3_bucket.datadog-failure.id
+  block_public_acls       = true
+  block_public_policy     = true
+  ignore_public_acls      = true
+  restrict_public_buckets = true
+}
+
+data "aws_iam_policy_document" "firehose_policy" {
+  statement {
+    effect = "Allow"
+    actions = [
+      "s3:AbortMultipartUpload",
+      "s3:GetBucketLocation",
+      "s3:ListBucket",
+      "s3:ListBucketMultipartUploads",
+      "s3:PutObject"
+    ]
+    // This bucket is single-purpose and using a wildcard is not problematic
+    resources = [
+      aws_s3_bucket.datadog-failure.arn,
+      "${aws_s3_bucket.datadog-failure.arn}/*"
+    ] #tfsec:ignore:aws-iam-no-policy-wildcards
+  }
+}
+
+resource "aws_iam_policy" "firehose" {
+  name   = "datadog_firehose_policy"
+  policy = data.aws_iam_policy_document.firehose_policy.json
+}
+
+resource "aws_iam_role" "firehose" {
+  assume_role_policy = data.aws_iam_policy_document.osquery_firehose_assume_role.json
+}
+
+resource "aws_iam_role_policy_attachment" "firehose" {
+  policy_arn = aws_iam_policy.firehose.arn
+  role       = aws_iam_role.firehose.name
+}
+
+data "aws_iam_policy_document" "osquery_firehose_assume_role" {
+  statement {
+    effect  = "Allow"
+    actions = ["sts:AssumeRole"]
+    principals {
+      identifiers = ["firehose.amazonaws.com"]
+      type        = "Service"
+    }
+  }
+}
+
+resource "aws_kinesis_firehose_delivery_stream" "datadog" {
+  for_each    = var.log_destinations
+  name        = each.value.name
+  destination = "http_endpoint"
+
+  http_endpoint_configuration {
+    url                = var.datadog_url
+    name               = "Datadog"
+    access_key         = var.datadog_api_key
+    buffering_size     = each.value.buffering_size
+    buffering_interval = each.value.buffering_interval
+    role_arn           = aws_iam_role.firehose.arn
+    s3_backup_mode     = "FailedDataOnly"
+
+    s3_configuration {
+      role_arn           = aws_iam_role.firehose.arn
+      bucket_arn         = aws_s3_bucket.datadog-failure.arn
+      buffering_size     = each.value.s3_buffering_size
+      buffering_interval = each.value.s3_buffering_interval
+      compression_format = var.compression_format
+    }
+
+    request_configuration {
+      content_encoding = each.value.compression_type
+
+      dynamic "common_attributes" {
+        for_each = each.value.common_attributes
+        content {
+          name  = common_attributes.value.name
+          value = common_attributes.value.value
+        }
+      }
+    }
+  }
+}
+
+data "aws_iam_policy_document" "firehose-logging" {
+  statement {
+    actions = [
+      "firehose:DescribeDeliveryStream",
+      "firehose:PutRecord",
+      "firehose:PutRecordBatch",
+    ]
+    resources = [for stream in aws_kinesis_firehose_delivery_stream.datadog : stream.arn]
+  }
+}
+
+resource "aws_iam_policy" "firehose-logging" {
+  description = "An IAM policy for fleet to log to Datadog via Firehose"
+  policy      = data.aws_iam_policy_document.firehose-logging.json
+}

--- a/addons/logging-destination-datadog/main.tf
+++ b/addons/logging-destination-datadog/main.tf
@@ -9,6 +9,9 @@ resource "aws_s3_bucket_lifecycle_configuration" "datadog-failure" {
   rule {
     status = "Enabled"
     id     = "expire"
+    filter {
+      prefix = ""
+    }
     expiration {
       days = var.s3_bucket_config.expires_days
     }
@@ -98,7 +101,7 @@ resource "aws_kinesis_firehose_delivery_stream" "datadog" {
     }
 
     request_configuration {
-      content_encoding = each.value.compression_type
+      content_encoding = each.value.content_encoding
 
       dynamic "common_attributes" {
         for_each = each.value.common_attributes

--- a/addons/logging-destination-datadog/outputs.tf
+++ b/addons/logging-destination-datadog/outputs.tf
@@ -1,0 +1,20 @@
+output "fleet_extra_environment_variables" {
+  value = {
+    FLEET_FIREHOSE_STATUS_STREAM    = aws_kinesis_firehose_delivery_stream.datadog["status"].name
+    FLEET_FIREHOSE_RESULT_STREAM    = aws_kinesis_firehose_delivery_stream.datadog["results"].name
+    FLEET_FIREHOSE_AUDIT_STREAM     = aws_kinesis_firehose_delivery_stream.datadog["audit"].name
+    FLEET_FIREHOSE_REGION           = data.aws_region.current.name
+    FLEET_OSQUERY_STATUS_LOG_PLUGIN = "firehose"
+    FLEET_OSQUERY_RESULT_LOG_PLUGIN = "firehose"
+    FLEET_ACTIVITY_AUDIT_LOG_PLUGIN = "firehose"
+    FLEET_ACTIVITY_ENABLE_AUDIT_LOG = "true"
+  }
+  description = "Environment variables to configure Fleet to use Datadog logging via Firehose"
+}
+
+output "fleet_extra_iam_policies" {
+  value = [
+    aws_iam_policy.firehose-logging.arn
+  ]
+  description = "IAM policies required for Fleet to log to Datadog via Firehose"
+}

--- a/addons/logging-destination-datadog/outputs.tf
+++ b/addons/logging-destination-datadog/outputs.tf
@@ -3,7 +3,7 @@ output "fleet_extra_environment_variables" {
     FLEET_FIREHOSE_STATUS_STREAM    = aws_kinesis_firehose_delivery_stream.datadog["status"].name
     FLEET_FIREHOSE_RESULT_STREAM    = aws_kinesis_firehose_delivery_stream.datadog["results"].name
     FLEET_FIREHOSE_AUDIT_STREAM     = aws_kinesis_firehose_delivery_stream.datadog["audit"].name
-    FLEET_FIREHOSE_REGION           = data.aws_region.current.name
+    FLEET_FIREHOSE_REGION           = data.aws_region.current.region
     FLEET_OSQUERY_STATUS_LOG_PLUGIN = "firehose"
     FLEET_OSQUERY_RESULT_LOG_PLUGIN = "firehose"
     FLEET_ACTIVITY_AUDIT_LOG_PLUGIN = "firehose"

--- a/addons/logging-destination-datadog/outputs.tf
+++ b/addons/logging-destination-datadog/outputs.tf
@@ -3,7 +3,7 @@ output "fleet_extra_environment_variables" {
     FLEET_FIREHOSE_STATUS_STREAM    = aws_kinesis_firehose_delivery_stream.datadog["status"].name
     FLEET_FIREHOSE_RESULT_STREAM    = aws_kinesis_firehose_delivery_stream.datadog["results"].name
     FLEET_FIREHOSE_AUDIT_STREAM     = aws_kinesis_firehose_delivery_stream.datadog["audit"].name
-    FLEET_FIREHOSE_REGION           = data.aws_region.current.region
+    FLEET_FIREHOSE_REGION           = data.aws_region.current.name
     FLEET_OSQUERY_STATUS_LOG_PLUGIN = "firehose"
     FLEET_OSQUERY_RESULT_LOG_PLUGIN = "firehose"
     FLEET_ACTIVITY_AUDIT_LOG_PLUGIN = "firehose"

--- a/addons/logging-destination-datadog/variables.tf
+++ b/addons/logging-destination-datadog/variables.tf
@@ -1,0 +1,73 @@
+variable "s3_bucket_config" {
+  type = object({
+    name_prefix  = optional(string, "fleet-datadog-failure")
+    expires_days = optional(number, 1)
+  })
+  default = {
+    name_prefix  = "fleet-datadog-failure"
+    expires_days = 1
+  }
+  description = "Configuration for the S3 bucket used to store failed Datadog delivery attempts"
+}
+
+variable "log_destinations" {
+  description = "A map of configurations for Datadog Firehose delivery streams."
+  type = map(object({
+    name                  = string
+    buffering_size        = number
+    buffering_interval    = number
+    s3_buffering_size     = number
+    s3_buffering_interval = number
+    compression_type      = string
+    common_attributes = optional(list(object({
+      name  = string
+      value = string
+    })), [])
+  }))
+  default = {
+    results = {
+      name                  = "fleet-osquery-results-datadog"
+      buffering_size        = 1
+      buffering_interval    = 60
+      s3_buffering_size     = 10
+      s3_buffering_interval = 400
+      compression_type      = "GZIP"
+      common_attributes     = []
+    },
+    status = {
+      name                  = "fleet-osquery-status-datadog"
+      buffering_size        = 1
+      buffering_interval    = 60
+      s3_buffering_size     = 10
+      s3_buffering_interval = 400
+      compression_type      = "GZIP"
+      common_attributes     = []
+    },
+    audit = {
+      name                  = "fleet-audit-datadog"
+      buffering_size        = 1
+      buffering_interval    = 60
+      s3_buffering_size     = 10
+      s3_buffering_interval = 400
+      compression_type      = "GZIP"
+      common_attributes     = []
+    }
+  }
+}
+
+variable "compression_format" {
+  default     = "GZIP"
+  description = "Compression format for the Firehose delivery stream"
+}
+
+variable "datadog_url" {
+  type        = string
+  description = "Datadog HTTP API endpoint URL"
+  default     = "https://aws-kinesis-http-intake.logs.datadoghq.com/v1/input"
+}
+
+variable "datadog_api_key" {
+  type        = string
+  description = "Datadog API key for authentication"
+  sensitive   = true
+}

--- a/addons/logging-destination-datadog/variables.tf
+++ b/addons/logging-destination-datadog/variables.tf
@@ -18,7 +18,7 @@ variable "log_destinations" {
     buffering_interval    = number
     s3_buffering_size     = number
     s3_buffering_interval = number
-    compression_type      = string
+    content_encoding      = string
     common_attributes = optional(list(object({
       name  = string
       value = string
@@ -27,43 +27,42 @@ variable "log_destinations" {
   default = {
     results = {
       name                  = "fleet-osquery-results-datadog"
-      buffering_size        = 1
+      buffering_size        = 2
       buffering_interval    = 60
       s3_buffering_size     = 10
       s3_buffering_interval = 400
-      compression_type      = "GZIP"
+      content_encoding      = "NONE"
       common_attributes     = []
     },
     status = {
       name                  = "fleet-osquery-status-datadog"
-      buffering_size        = 1
+      buffering_size        = 2
       buffering_interval    = 60
       s3_buffering_size     = 10
       s3_buffering_interval = 400
-      compression_type      = "GZIP"
+      content_encoding      = "NONE"
       common_attributes     = []
     },
     audit = {
       name                  = "fleet-audit-datadog"
-      buffering_size        = 1
+      buffering_size        = 2
       buffering_interval    = 60
       s3_buffering_size     = 10
       s3_buffering_interval = 400
-      compression_type      = "GZIP"
+      content_encoding      = "NONE"
       common_attributes     = []
     }
   }
 }
 
 variable "compression_format" {
-  default     = "GZIP"
+  default     = "UNCOMPRESSED"
   description = "Compression format for the Firehose delivery stream"
 }
 
 variable "datadog_url" {
   type        = string
   description = "Datadog HTTP API endpoint URL"
-  default     = "https://aws-kinesis-http-intake.logs.datadoghq.com/v1/input"
 }
 
 variable "datadog_api_key" {


### PR DESCRIPTION
sets up an addon we can use to get a readily configured firehose delivery stream that has the Datadog sink configured