### PR TITLE
s3 lifecycle updates

### DIFF
--- a/addons/logging-alb/main.tf
+++ b/addons/logging-alb/main.tf
@@ -234,7 +234,7 @@ module "athena-s3-bucket" {
         newer_noncurrent_versions = var.s3_newer_noncurrent_versions
         days                      = var.s3_noncurrent_version_expiration_days
       }
-      filter = {}
+      filter = []
     }
   ]
 }

--- a/addons/logging-alb/main.tf
+++ b/addons/logging-alb/main.tf
@@ -169,7 +169,7 @@ module "s3_bucket_for_logs" {
       expiration = {
         days = var.s3_expiration_days
         # Always resets to false anyhow showing terraform changes constantly
-        expired_object_delete_marker = false
+        # expired_object_delete_marker = false
       }
       noncurrent_version_expiration = {
         newer_noncurrent_versions = var.s3_newer_noncurrent_versions
@@ -228,7 +228,7 @@ module "athena-s3-bucket" {
       expiration = {
         days = var.s3_expiration_days
         # Always resets to false anyhow showing terraform changes constantly
-        expired_object_delete_marker = false
+        # expired_object_delete_marker = false
       }
       noncurrent_version_expiration = {
         newer_noncurrent_versions = var.s3_newer_noncurrent_versions

--- a/addons/logging-alb/main.tf
+++ b/addons/logging-alb/main.tf
@@ -233,7 +233,7 @@ module "athena-s3-bucket" {
         newer_noncurrent_versions = var.s3_newer_noncurrent_versions
         days                      = var.s3_noncurrent_version_expiration_days
       }
-      filter {}
+      filter = {}
     }
   ]
 }

--- a/addons/logging-alb/main.tf
+++ b/addons/logging-alb/main.tf
@@ -175,7 +175,7 @@ module "s3_bucket_for_logs" {
         newer_noncurrent_versions = var.s3_newer_noncurrent_versions
         days                      = var.s3_noncurrent_version_expiration_days
       }
-      filter = {}
+      filter = []
     }
   ]
 }

--- a/addons/logging-alb/main.tf
+++ b/addons/logging-alb/main.tf
@@ -233,6 +233,7 @@ module "athena-s3-bucket" {
         newer_noncurrent_versions = var.s3_newer_noncurrent_versions
         days                      = var.s3_noncurrent_version_expiration_days
       }
+      filter {}
     }
   ]
 }

--- a/addons/logging-alb/main.tf
+++ b/addons/logging-alb/main.tf
@@ -175,6 +175,7 @@ module "s3_bucket_for_logs" {
         newer_noncurrent_versions = var.s3_newer_noncurrent_versions
         days                      = var.s3_noncurrent_version_expiration_days
       }
+      filter = {}
     }
   ]
 }

--- a/addons/logging-destination-firehose/main.tf
+++ b/addons/logging-destination-firehose/main.tf
@@ -19,6 +19,7 @@ resource "aws_s3_bucket_lifecycle_configuration" "osquery-results" {
     expiration {
       days = var.osquery_results_s3_bucket.expires_days
     }
+    filter {}
   }
 }
 
@@ -57,6 +58,7 @@ resource "aws_s3_bucket_lifecycle_configuration" "osquery-status" {
     expiration {
       days = var.osquery_status_s3_bucket.expires_days
     }
+    filter {}
   }
 }
 

--- a/addons/osquery-carve/main.tf
+++ b/addons/osquery-carve/main.tf
@@ -17,6 +17,7 @@ resource "aws_s3_bucket_lifecycle_configuration" "main" {
     expiration {
       days = var.osquery_carve_s3_bucket.expires_days
     }
+    filter {}
   }
 }
 

--- a/byo-vpc/byo-db/byo-ecs/main.tf
+++ b/byo-vpc/byo-db/byo-ecs/main.tf
@@ -319,6 +319,7 @@ resource "aws_s3_bucket_lifecycle_configuration" "software_installers" {
       noncurrent_days = 30
     }
     status = "Enabled"
+    filter {}
   }
 }
 


### PR DESCRIPTION
- Added `filter {}` to  resource `aws_s3_bucket_lifecycle_configuration` block(s)
- Added filter = [] to `module.s3_bucket_for_logs in addons/logging-alb/main.tf`
- Added filter = [] to `module.athena-s3-bucket in addons/logging-alb/main.tf`

---

Addresses the following warnings.
```
No attribute specified when one (and only one) of [rule[0].filter,rule[0].prefix] is required
```

---

```
╷
│ Warning: Invalid Attribute Combination
│ 
│   with module.logging_alb.module.athena-s3-bucket[0].aws_s3_bucket_lifecycle_configuration.this[0],
│   on .terraform/modules/logging_alb.athena-s3-bucket/main.tf line 219, in resource "aws_s3_bucket_lifecycle_configuration" "this":
│  219: resource "aws_s3_bucket_lifecycle_configuration" "this" {
│ 
│ 2 attributes specified when one (and only one) of [rule[0].expiration[0].date,rule[0].expiration[0].days,rule[0].expiration[0].expired_object_delete_marker] is required
```