### PR TITLE
add serverless db capabilities

### DIFF
--- a/byo-vpc/main.tf
+++ b/byo-vpc/main.tf
@@ -53,6 +53,11 @@ module "rds" {
 
   instances = local.rds_replica_instances
 
+  serverlessv2_scaling_configuration = var.rds_config.serverless ? {
+    min_capacity = var.rds_config.serverless_min_capacity
+    max_capacity = var.rds_config.serverless_max_capacity
+  } : null
+
   vpc_id  = var.vpc_config.vpc_id
   subnets = var.rds_config.subnets
 

--- a/byo-vpc/variables.tf
+++ b/byo-vpc/variables.tf
@@ -29,6 +29,9 @@ variable "rds_config" {
     skip_final_snapshot             = optional(bool, true)
     backup_retention_period         = optional(number, 7)
     replicas                        = optional(number, 2)
+    serverless                      = optional(bool, false)
+    serverless_min_capacity         = optional(number, 2)
+    serverless_max_capacity         = optional(number, 10)
   })
   default = {
     name                            = "fleet"
@@ -51,6 +54,9 @@ variable "rds_config" {
     skip_final_snapshot             = true
     backup_retention_period         = 7
     replicas                        = 2
+    serverless                      = false
+    serverless_min_capacity         = 2
+    serverless_max_capacity         = 10
   }
   description = "The config for the terraform-aws-modules/rds-aurora/aws module"
   nullable    = false


### PR DESCRIPTION
Currently, the byo-vpc module doesn't provide a way to use serverless options from the rds module. This adds 3 new variables for the rds options, to make serverless installations possible for rds.
