### PR TITLE
Engine version from 8.0.mysql_aurora.3.07.1 -> 8.0.mysql_aurora.3.08.2

### DIFF
--- a/example/main.tf
+++ b/example/main.tf
@@ -52,7 +52,7 @@ locals {
 }
 
 module "fleet" {
-  source          = "github.com/fleetdm/fleet-terraform?depth=1&ref=tf-mod-root-v1.16.0"
+  source          = "github.com/fleetdm/fleet-terraform?depth=1&ref=tf-mod-root-v1.16.1"
   certificate_arn = module.acm.acm_certificate_arn
 
   vpc = {
@@ -102,7 +102,7 @@ module "fleet" {
       sort_buffer_size = 8388608
     }
     # Uncomment to specify the RDS engine version
-    # engine_version = "8.0.mysql_aurora.3.07.1"
+    # engine_version = "8.0.mysql_aurora.3.08.2"
     # Uncomment to use more or fewer replicas
     # replicas = 2
   }

--- a/variables.tf
+++ b/variables.tf
@@ -62,7 +62,7 @@ variable "certificate_arn" {
 variable "rds_config" {
   type = object({
     name                            = optional(string, "fleet")
-    engine_version                  = optional(string, "8.0.mysql_aurora.3.07.1")
+    engine_version                  = optional(string, "8.0.mysql_aurora.3.08.2")
     instance_class                  = optional(string, "db.t4g.large")
     subnets                         = optional(list(string), [])
     allowed_security_groups         = optional(list(string), [])
@@ -86,7 +86,7 @@ variable "rds_config" {
   })
   default = {
     name                            = "fleet"
-    engine_version                  = "8.0.mysql_aurora.3.07.1"
+    engine_version                  = "8.0.mysql_aurora.3.08.2"
     instance_class                  = "db.t4g.large"
     subnets                         = []
     allowed_security_groups         = []


### PR DESCRIPTION
- MySQL engine_version bumped from `8.0.mysql_aurora.3.07.1` -> `8.0.mysql_aurora.3.08.2` in `example/main.tf`
- MySQL engine_version bumped from `8.0.mysql_aurora.3.07.1` -> `8.0.mysql_aurora.3.08.2` in `variables.tf`
- Root module version in `example/main.tf` bumped to `tf-mod-root-v1.16.1`