### PR TITLE
Fixing default value for var.serverlessv2_scaling_configuration 

### DIFF
--- a/byo-vpc/main.tf
+++ b/byo-vpc/main.tf
@@ -56,7 +56,7 @@ module "rds" {
   serverlessv2_scaling_configuration = var.rds_config.serverless ? {
     min_capacity = var.rds_config.serverless_min_capacity
     max_capacity = var.rds_config.serverless_max_capacity
-  } : null
+  } : {}
 
   vpc_id  = var.vpc_config.vpc_id
   subnets = var.rds_config.subnets

--- a/example/main.tf
+++ b/example/main.tf
@@ -52,7 +52,7 @@ locals {
 }
 
 module "fleet" {
-  source          = "github.com/fleetdm/fleet-terraform?depth=1&ref=tf-mod-root-v1.16.1"
+  source          = "github.com/fleetdm/fleet-terraform?depth=1&ref=tf-mod-root-v1.16.2"
   certificate_arn = module.acm.acm_certificate_arn
 
   vpc = {


### PR DESCRIPTION
* Default value when `var.serverlessv2_scaling_configuration` is not defined modified from `null` -> `{}`
* Example updated to use git tag:`tf-mod-root-v1.16.2`