### PR TITLE
Add custom domain support to SES module

### DIFF
--- a/addons/ses/README.md
+++ b/addons/ses/README.md
@@ -26,6 +26,7 @@ No modules.
 | [aws_route53_record.spf_domain](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/route53_record) | resource |
 | [aws_ses_domain_dkim.default](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/ses_domain_dkim) | resource |
 | [aws_ses_domain_identity.default](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/ses_domain_identity) | resource |
+| [aws_ses_domain_mail_from.default](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/ses_domain_mail_from) | resource |
 | [aws_iam_policy_document.main](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
 | [aws_region.current](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/region) | data source |
 
@@ -33,7 +34,7 @@ No modules.
 
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
-| <a name="input_custom_domain"></a> [custom\_domain](#input\_custom\_domain) | Custom domain to add an MX record for. | `string` | `""` | no |
+| <a name="input_custom_mail_from"></a> [custom\_mail\_from](#input\_custom\_mail\_from) | Custom MAIL FROM domain settings | <pre>object({<br/>    enabled       = optional(bool, false)<br/>    domain_prefix = optional(string, "")<br/>  })</pre> | <pre>{<br/>  "domain_prefix": "",<br/>  "enabled": false<br/>}</pre> | no |
 | <a name="input_domain"></a> [domain](#input\_domain) | Domain to use for SES. | `string` | n/a | yes |
 | <a name="input_extra_txt_records"></a> [extra\_txt\_records](#input\_extra\_txt\_records) | Extra TXT records that have to match the same name as the Fleet instance | `list(string)` | `[]` | no |
 | <a name="input_zone_id"></a> [zone\_id](#input\_zone\_id) | Route53 Zone ID | `string` | n/a | yes |

--- a/addons/ses/README.md
+++ b/addons/ses/README.md
@@ -9,7 +9,7 @@ No requirements.
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | 4.62.2 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | 6.7.0 |
 
 ## Modules
 
@@ -21,15 +21,19 @@ No modules.
 |------|------|
 | [aws_iam_policy.main](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_policy) | resource |
 | [aws_route53_record.amazonses_dkim_record](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/route53_record) | resource |
+| [aws_route53_record.dmarc_domain](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/route53_record) | resource |
+| [aws_route53_record.mx_record](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/route53_record) | resource |
 | [aws_route53_record.spf_domain](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/route53_record) | resource |
 | [aws_ses_domain_dkim.default](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/ses_domain_dkim) | resource |
 | [aws_ses_domain_identity.default](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/ses_domain_identity) | resource |
 | [aws_iam_policy_document.main](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
+| [aws_region.current](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/region) | data source |
 
 ## Inputs
 
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
+| <a name="input_custom_domain"></a> [custom\_domain](#input\_custom\_domain) | Custom domain to add an MX record for. | `string` | `""` | no |
 | <a name="input_domain"></a> [domain](#input\_domain) | Domain to use for SES. | `string` | n/a | yes |
 | <a name="input_extra_txt_records"></a> [extra\_txt\_records](#input\_extra\_txt\_records) | Extra TXT records that have to match the same name as the Fleet instance | `list(string)` | `[]` | no |
 | <a name="input_zone_id"></a> [zone\_id](#input\_zone\_id) | Route53 Zone ID | `string` | n/a | yes |

--- a/addons/ses/main.tf
+++ b/addons/ses/main.tf
@@ -1,7 +1,7 @@
 locals {
   spf_domains = [
     aws_ses_domain_identity.default.domain,
-    "_amazonses.${aws_ses_domain_identity.default.domain}"
+    # "_amazonses.${aws_ses_domain_identity.default.domain}"
   ]
   dmarc_domain = "_dmarc.${aws_ses_domain_identity.default.domain}"
 }

--- a/addons/ses/main.tf
+++ b/addons/ses/main.tf
@@ -2,7 +2,7 @@ locals {
   spf_domains = concat([
     aws_ses_domain_identity.default.domain,
     "_amazonses.${aws_ses_domain_identity.default.domain}",
-    var.custom_mail_from.enabled == true ? "${var.custom_mail_from.domain_prefix}.${aws_ses_domain_identity.default.domain}" : null
+    var.custom_mail_from.enabled == true ? "${var.custom_mail_from.domain_prefix}.${aws_ses_domain_identity.default.domain}" : ""
   ])
   dmarc_domain = "_dmarc.${aws_ses_domain_identity.default.domain}"
 }

--- a/addons/ses/main.tf
+++ b/addons/ses/main.tf
@@ -1,7 +1,7 @@
 locals {
   spf_domains = [
     aws_ses_domain_identity.default.domain,
-    # "_amazonses.${aws_ses_domain_identity.default.domain}"
+    "_amazonses.${aws_ses_domain_identity.default.domain}"
   ]
   dmarc_domain = "_dmarc.${aws_ses_domain_identity.default.domain}"
 }

--- a/addons/ses/main.tf
+++ b/addons/ses/main.tf
@@ -21,6 +21,14 @@ resource "aws_ses_domain_mail_from" "default" {
   mail_from_domain = "mail.${aws_ses_domain_identity.default.domain}"
 }
 
+resource "aws_route53_record" "spf_domain_custom_mail_from" {
+  zone_id  = var.zone_id
+  name     = "mail.${aws_ses_domain_identity.default.domain}"
+  type     = "TXT"
+  ttl      = "600"
+  records  = ["v=spf1 include:amazonses.com -all"]
+}
+
 ###MX RECORD###
 resource "aws_route53_record" "mx_record" {
   zone_id = var.zone_id
@@ -47,8 +55,7 @@ resource "aws_route53_record" "spf_domain" {
   name     = each.key
   type     = "TXT"
   ttl      = "600"
-  #records  = each.key == aws_ses_domain_identity.default.domain ? flatten([["v=spf1 include:amazonses.com -all"], var.extra_txt_records]) : ["v=spf1 include:amazonses.com -all"]
-  records  = each.key == aws_ses_domain_identity.default.domain ? flatten([["v=spf1 include:amazonses.com -all"], var.extra_txt_records]) : ["v=spf1 include:mail.${aws_ses_domain_identity.default.domain} -all"]
+  records  = each.key == aws_ses_domain_identity.default.domain ? flatten([["v=spf1 include:amazonses.com -all"], var.extra_txt_records]) : ["v=spf1 include:amazonses.com -all"]
 }
 
 resource "aws_route53_record" "dmarc_domain" {

--- a/addons/ses/main.tf
+++ b/addons/ses/main.tf
@@ -1,9 +1,9 @@
 locals {
-  spf_domains = concat([
+  spf_domains = compact(concat([
     aws_ses_domain_identity.default.domain,
     "_amazonses.${aws_ses_domain_identity.default.domain}",
-    var.custom_mail_from.enabled == true ? "${var.custom_mail_from.domain_prefix}.${aws_ses_domain_identity.default.domain}" : ""
-  ])
+    var.custom_mail_from.enabled == true ? "${var.custom_mail_from.domain_prefix}.${aws_ses_domain_identity.default.domain}" : null
+  ]))
   dmarc_domain = "_dmarc.${aws_ses_domain_identity.default.domain}"
 }
 

--- a/addons/ses/main.tf
+++ b/addons/ses/main.tf
@@ -2,7 +2,7 @@ locals {
   spf_domains = concat([
     aws_ses_domain_identity.default.domain,
     "_amazonses.${aws_ses_domain_identity.default.domain}",
-    var.custom_mail_from.enabled == true ? var.custom_mail_from.domain_prefix : null
+    var.custom_mail_from.enabled == true ? "${var.custom_mail_from.domain_prefix}.${aws_ses_domain_identity.default.domain}" : null
   ])
   dmarc_domain = "_dmarc.${aws_ses_domain_identity.default.domain}"
 }

--- a/addons/ses/main.tf
+++ b/addons/ses/main.tf
@@ -21,7 +21,7 @@ resource "aws_route53_record" "mx_record" {
   count   = var.custom_domain != "" ? 1 : 0
   zone_id = var.zone_id
   name    = var.custom_domain
-  type    = "CNAME"
+  type    = "MX"
   ttl     = "600"
   records = ["10 feedback-smtp.${data.aws_region.current.region}.amazonses.com"]
 }

--- a/addons/ses/main.tf
+++ b/addons/ses/main.tf
@@ -28,7 +28,7 @@ resource "aws_ses_domain_mail_from" "default" {
 resource "aws_route53_record" "mx_record" {
   count   = var.custom_mail_from.enabled == true ? 1 : 0
   zone_id = var.zone_id
-  name    = aws_ses_domain_mail_from.default.mail_from_domain[count.index]
+  name    = aws_ses_domain_mail_from.default[count.index].mail_from_domain
   type    = "MX"
   ttl     = "600"
   records = ["10 feedback-smtp.${data.aws_region.current.region}.amazonses.com"]

--- a/addons/ses/variables.tf
+++ b/addons/ses/variables.tf
@@ -13,9 +13,3 @@ variable "extra_txt_records" {
   description = "Extra TXT records that have to match the same name as the Fleet instance"
   default     = []
 }
-
-variable "custom_domain" {
-  type        = string
-  description = "Custom domain to add an MX record for."
-  default     = ""
-}

--- a/addons/ses/variables.tf
+++ b/addons/ses/variables.tf
@@ -13,3 +13,9 @@ variable "extra_txt_records" {
   description = "Extra TXT records that have to match the same name as the Fleet instance"
   default     = []
 }
+
+variable "custom_domain" {
+  type        = string
+  description = "Custom domain to add an MX record for."
+  default     = ""
+}

--- a/addons/ses/variables.tf
+++ b/addons/ses/variables.tf
@@ -13,3 +13,12 @@ variable "extra_txt_records" {
   description = "Extra TXT records that have to match the same name as the Fleet instance"
   default     = []
 }
+
+variable "custom_mail_from" {
+  type        = object({
+    enabled   = optional(bool, false)
+    domain_prefix = optional(string, "")
+  })
+  description = "Custom MAIL FROM domain settings"
+  default     = ""
+}

--- a/addons/ses/variables.tf
+++ b/addons/ses/variables.tf
@@ -20,5 +20,4 @@ variable "custom_mail_from" {
     domain_prefix = optional(string, "")
   })
   description = "Custom MAIL FROM domain settings"
-  default     = ""
 }

--- a/addons/ses/variables.tf
+++ b/addons/ses/variables.tf
@@ -15,9 +15,13 @@ variable "extra_txt_records" {
 }
 
 variable "custom_mail_from" {
-  type        = object({
-    enabled   = optional(bool, false)
+  type = object({
+    enabled       = optional(bool, false)
     domain_prefix = optional(string, "")
   })
+  default = {
+    enabled       = false
+    domain_prefix = ""
+  }
   description = "Custom MAIL FROM domain settings"
 }


### PR DESCRIPTION
- Added variable to drive custom mail from configuration
- Added resource for MX record to a specific route 53 zone, if custom mail value from is enabled
- Add SPF record to local.spf_records list, if custom mail value from is enabled. Current spf resource takes care of
  - Creating the record if the value is present
  - Destroying the record if the value is not present (when disabled or variable is not set)