### PR TITLE
Support for internal load balancer, iam policy attachment processing, and cloudfront software installers

### DIFF
--- a/addons/cloudfront-software-installers/main.tf
+++ b/addons/cloudfront-software-installers/main.tf
@@ -53,6 +53,7 @@ data "aws_iam_policy_document" "software_installers_kms" {
 }
 
 resource "aws_kms_key_policy" "software_installers" {
+  count  = var.s3_kms_key_id != null ? 1 : 0
   key_id = var.s3_kms_key_id
   policy = data.aws_iam_policy_document.software_installers_kms.json
 }

--- a/addons/cloudfront-software-installers/variables.tf
+++ b/addons/cloudfront-software-installers/variables.tf
@@ -22,6 +22,7 @@ variable "s3_bucket" {
 variable "s3_kms_key_id" {
   description = "KMS key id used to encrypt the s3 bucket"
   type        = string
+  default     = null
 }
 
 variable "enable_logging" {

--- a/byo-vpc/byo-db/byo-ecs/iam.tf
+++ b/byo-vpc/byo-db/byo-ecs/iam.tf
@@ -119,14 +119,14 @@ resource "aws_iam_role_policy_attachment" "main" {
 }
 
 resource "aws_iam_role_policy_attachment" "extras" {
-  for_each   = toset(var.fleet_config.extra_iam_policies)
-  policy_arn = each.value
+  count      = length(var.fleet_config.extra_iam_policies)
+  policy_arn = var.fleet_config.extra_iam_policies[count.index]
   role       = aws_iam_role.main[0].name
 }
 
 resource "aws_iam_role_policy_attachment" "execution_extras" {
-  for_each   = toset(var.fleet_config.extra_execution_iam_policies)
-  policy_arn = each.value
+  count      = length(var.fleet_config.extra_execution_iam_policies)
+  policy_arn = var.fleet_config.extra_execution_iam_policies[count.index]
   role       = aws_iam_role.execution.name
 }
 

--- a/byo-vpc/byo-db/main.tf
+++ b/byo-vpc/byo-db/main.tf
@@ -52,6 +52,7 @@ module "alb" {
   security_groups = concat(var.alb_config.security_groups, [aws_security_group.alb.id])
   access_logs     = var.alb_config.access_logs
   idle_timeout    = var.alb_config.idle_timeout
+  internal        = var.alb_config.internal
 
   target_groups = concat([
     {

--- a/byo-vpc/byo-db/variables.tf
+++ b/byo-vpc/byo-db/variables.tf
@@ -322,5 +322,6 @@ variable "alb_config" {
     https_listener_rules = optional(any, [])
     tls_policy           = optional(string, "ELBSecurityPolicy-TLS13-1-2-2021-06")
     idle_timeout         = optional(number, 905)
+    internal             = optional(bool, false)
   })
 }

--- a/byo-vpc/variables.tf
+++ b/byo-vpc/variables.tf
@@ -427,5 +427,6 @@ variable "alb_config" {
     https_listener_rules = optional(any, [])
     tls_policy           = optional(string, "ELBSecurityPolicy-TLS13-1-2-2021-06")
     idle_timeout         = optional(number, 905)
+    internal             = optional(bool, false)
   })
 }

--- a/variables.tf
+++ b/variables.tf
@@ -473,6 +473,7 @@ variable "alb_config" {
     https_listener_rules = optional(any, [])
     tls_policy           = optional(string, "ELBSecurityPolicy-TLS13-1-2-2021-06")
     idle_timeout         = optional(number, 905)
+    internal             = optional(bool, false)
   })
   default = {}
 }


### PR DESCRIPTION
# Main terraform

- Modified iam `resource "aws_iam_role_policy_attachment" "extras"` from `for_each` to `count`, which allows terraform to apply even if roles are not yet created. In cases where role is not yet created, a second terraform apply is required for the resource to attach the policy.
- Modified iam `resource "aws_iam_role_policy_attachment" "execution_extras"`, which allows terraform to apply even if roles are not yet created. In cases where role is not yet created, a second terraform apply is required for the resource to attach the policy.
- Added support for internal load balancers to be provisioned.

# Module: Cloudfront Software Installers

- Added a count & tertiary to cloudfront software installer kms key policy, as it's fed in as an input. In cases where the key had not yet been created, apply would fail.
- Modified `variable "s3_kms_key_id"` to allow default value `null`