### PR TITLE
Add --max-capacity support to migrate.sh

### DIFF
--- a/addons/migrations/migrate.sh
+++ b/addons/migrations/migrate.sh
@@ -17,9 +17,10 @@ function scale_services(){
 		CAPACITY="${MIN_CAPACITY:?}"
 	fi
 
-  if [ -n "${ADJUST_AUTOSCALING}" ]; then
-    aws application-autoscaling register-scalable-target --region "${REGION:?}" --service-namespace ecs --resource-id "service/${ECS_CLUSTER:?}/${SERVICE_NAME:?}" --scalable-dimension "ecs:service:DesiredCount" --min-capacity "${CAPACITY:?}"
-  fi
+	if [ -n "${ADJUST_AUTOSCALING}" ]; then
+		aws application-autoscaling register-scalable-target --region "${REGION:?}" --service-namespace ecs --resource-id "service/${ECS_CLUSTER:?}/${SERVICE_NAME:?}" --scalable-dimension "ecs:service:DesiredCount" --min-capacity "${CAPACITY:?}" --max-capacity "${COUNT:?}"
+	fi
+	
 	# We are scaling down, make it 0
 	if [ "${UP_DOWN:?}" != "up" ]; then
 		aws ecs update-service --region "${REGION:?}" --cluster "${ECS_CLUSTER:?}" --service "${SERVICE_NAME:?}" --desired-count 0

--- a/example/main.tf
+++ b/example/main.tf
@@ -256,7 +256,7 @@ module "fleet" {
 # doesn't directly support all the features required.  the aws cli is invoked via a null-resource.
 
 module "migrations" {
-  source                   = "github.com/fleetdm/fleet-terraform/addons/migrations?depth=1&ref=tf-mod-addon-migrations-v2.1.0"
+  source                   = "github.com/fleetdm/fleet-terraform/addons/migrations?depth=1&ref=tf-mod-addon-migrations-v2.1.1"
   ecs_cluster              = module.fleet.byo-vpc.byo-db.byo-ecs.service.cluster
   task_definition          = module.fleet.byo-vpc.byo-db.byo-ecs.task_definition.family
   task_definition_revision = module.fleet.byo-vpc.byo-db.byo-ecs.task_definition.revision


### PR DESCRIPTION
- Adding support for `--max-capacity` in the `${ADJUST_AUTOSCALING}` logic
- Updated example/main.tf with the upcoming migrations tag, containing the changes in this PR - `tf-mod-addon-migrations-v2.1.1`