### PR TITLE
Bumping tf k8s example source module reference to 1.2.0

### DIFF
--- a/k8s/example/main.tf
+++ b/k8s/example/main.tf
@@ -189,8 +189,23 @@ module "fleet" {
             s3 = {
                 bucket_name = ""
                 prefix = ""
+                endpoint_url = ""
+                force_s3_path_style = false
+                region = ""
                 access_key_id = ""
                 secret_key = "s3-bucket"
+                sts_assume_role_arn = ""
+            }
+        }
+        software_installers = {
+            s3 = {
+                bucket_name = ""
+                prefix = ""
+                endpoint_url = ""
+                force_s3_path_style = false
+                region = ""
+                access_key_id = ""
+                secret_key = "s3-software-installers"
                 sts_assume_role_arn = ""
             }
         }


### PR DESCRIPTION
- `k8s/example/main.tf` source update from `tf-mod-k8s-v1.1.3` -> `tf-mod-k8s-v1.2.0`
- Adds new configurations for `carving` and `softwareinstallers` configuration sections