### PR TITLE
Fixes migration script issue with max_capacity value getting set to 1 when scaling up

### DIFF
--- a/addons/migrations/migrate.sh
+++ b/addons/migrations/migrate.sh
@@ -6,7 +6,6 @@ function scale_services(){
 	SERVICE_NAME="${2:?}" # Take service name as an argument
 	ADJUST_AUTOSCALING="${3:-}"
 	COUNT="${4:-1}"
-	MAX_CAPACITY="${5:-1}"
 
 	# Set the minimum capacity and desired count in the cluster to 0 to scale down or to the original size to scale back to normal.
 
@@ -17,7 +16,7 @@ function scale_services(){
 	if [ "${UP_DOWN:?}" = "up" ]; then
 		aws ecs update-service --region "${REGION:?}" --cluster "${ECS_CLUSTER:?}" --service "${SERVICE_NAME:?}" --desired-count "${COUNT:?}"
 		CAPACITY="${MIN_CAPACITY:?}"
-		CAPACITY_MAX="${MAX_CAPACITY}"
+		CAPACITY_MAX="${MAX_CAPACITY:?}"
 	fi
 
 	if [ -n "${ADJUST_AUTOSCALING}" ]; then
@@ -58,7 +57,7 @@ if [ -n "${ASSUME_ROLE_ARN:-}" ]; then
   export AWS_ACCESS_KEY_ID AWS_SECRET_ACCESS_KEY AWS_SESSION_TOKEN
 fi
 
-scale_services down "${ECS_SERVICE:?}" true "${DESIRED_COUNT}" "${MAX_CAPACITY}"
+scale_services down "${ECS_SERVICE:?}" true "${DESIRED_COUNT}"
 
 if [ -n "${VULN_SERVICE}" ]; then
   scale_services down "${VULN_SERVICE:?}"
@@ -70,7 +69,7 @@ TASK_ARN="$(aws ecs run-task --region "${REGION:?}" --cluster "${ECS_CLUSTER:?}"
 # Wait for completion
 aws ecs wait tasks-stopped --region "${REGION:?}" --cluster="${ECS_CLUSTER:?}" --tasks="${TASK_ARN:?}"
 
-scale_services up "${ECS_SERVICE:?}" true "${DESIRED_COUNT}" "${MAX_CAPACITY}"
+scale_services up "${ECS_SERVICE:?}" true "${DESIRED_COUNT}"
 
 if [ -n "${VULN_SERVICE}" ]; then
   scale_services up "${VULN_SERVICE:?}"


### PR DESCRIPTION
- Fixes how MAX_CAPACITY is being used to avoid value getting set to 1, leading to failure scaling up.