### PR TITLE
Update monitoring example.

### DIFF
--- a/addons/monitoring/.header.md
+++ b/addons/monitoring/.header.md
@@ -12,12 +12,12 @@ This includes:
 
 # Preparation
 
-> Note: The documented examples and links in this README may assume use of `module.main` instead of `module.fleet`. The monitoring example configuration can be modified as documented below, if your fleet module is named `fleet` instead of `main`
-> - A search and replace of `module.main` -> `module.fleet`
+> Note: The documented examples and links in this README may assume use of `module.fleet` instead of `module.fleet`. The monitoring example configuration can be modified as documented below, if your fleet module is named `fleet` instead of `main`
+> - A search and replace of `module.fleet` -> `module.fleet`
 
 Some of the for_each and counts in this module cannot pre-determine the numbers until the `main` fleet module is applied.
 
-You will need to `terraform apply -target module.main` prior to applying monitoring assuming the use of a configuration matching the example at https://github.com/fleetdm/fleet-terraform/blob/main/example/main.tf. 
+You will need to `terraform apply -target module.fleet` prior to applying monitoring assuming the use of a configuration matching the example at https://github.com/fleetdm/fleet-terraform/blob/main/example/main.tf. 
 
 Multiple alb support was added in order to allow monitoring `saml-auth-proxy`. See https://github.com/fleetdm/fleet-terraform/tree/main/addons/saml-auth-proxy
 
@@ -31,17 +31,17 @@ https://github.com/fleetdm/fleet-terraform/blob/main/example/main.tf for details
 
 ```
 module "monitoring" {
-  source                 = "github.com/fleetdm/fleet-terraform//addons/monitoring?ref=tf-mod-addon-monitoring-v1.7.0"
+  source                 = "github.com/fleetdm/fleet-terraform//addons/monitoring?ref=tf-mod-addon-monitoring-v1.8.0"
   customer_prefix        = local.customer
-  fleet_ecs_service_name = module.main.byo-vpc.byo-db.byo-ecs.service.name
+  fleet_ecs_service_name = module.fleet.byo-vpc.byo-db.byo-ecs.service.name
   albs = [
     {
-      name                    = module.main.byo-vpc.byo-db.alb.lb_dns_name,
-      target_group_name       = module.main.byo-vpc.byo-db.alb.target_group_names[0]
-      target_group_arn_suffix = module.main.byo-vpc.byo-db.alb.target_group_arn_suffixes[0]
-      arn_suffix              = module.main.byo-vpc.byo-db.alb.lb_arn_suffix
-      ecs_service_name        = module.main.byo-vpc.byo-db.byo-ecs.service.name
-      min_containers          = module.main.byo-vpc.byo-db.byo-ecs.appautoscaling_target.min_capacity
+      name                    = module.fleet.byo-vpc.byo-db.alb.lb_dns_name,
+      target_group_name       = module.fleet.byo-vpc.byo-db.alb.target_group_names[0]
+      target_group_arn_suffix = module.fleet.byo-vpc.byo-db.alb.target_group_arn_suffixes[0]
+      arn_suffix              = module.fleet.byo-vpc.byo-db.alb.lb_arn_suffix
+      ecs_service_name        = module.fleet.byo-vpc.byo-db.byo-ecs.service.name
+      min_containers          = module.fleet.byo-vpc.byo-db.byo-ecs.appautoscaling_target.min_capacity
       alert_thresholds = {
         HTTPCode_ELB_5XX_Count = {
           period    = 3600
@@ -55,22 +55,23 @@ module "monitoring" {
     },
   ]
   sns_topic_arns_map = {
+    log_monitoring   = [var.sns_topic_arn]
     alb_httpcode_5xx = [var.sns_topic_arn]
     cron_monitoring  = [var.sns_topic_arn]
     cron_job_failure_monitoring  = [var.sns_another_topic_arn]
   }
-  mysql_cluster_members = module.main.byo-vpc.rds.cluster_members
+  mysql_cluster_members = module.fleet.byo-vpc.rds.cluster_members
   # The cloudposse module seems to have a nested list here.
-  redis_cluster_members = module.main.byo-vpc.redis.member_clusters[0]
+  redis_cluster_members = module.fleet.byo-vpc.redis.member_clusters[0]
   acm_certificate_arn   = module.acm.acm_certificate_arn
   cron_monitoring = {
-    mysql_host                 = module.main.byo-vpc.rds.cluster_reader_endpoint
-    mysql_database             = module.main.byo-vpc.rds.cluster_database_name
-    mysql_user                 = module.main.byo-vpc.rds.cluster_master_username
-    mysql_password_secret_name = module.main.byo-vpc.secrets.secret_ids["${local.customer}-database-password"]
-    rds_security_group_id      = module.main.byo-vpc.rds.security_group_id
-    subnet_ids                 = module.main.vpc.private_subnets
-    vpc_id                     = module.main.vpc.vpc_id
+    mysql_host                 = module.fleet.byo-vpc.rds.cluster_reader_endpoint
+    mysql_database             = module.fleet.byo-vpc.rds.cluster_database_name
+    mysql_user                 = module.fleet.byo-vpc.rds.cluster_master_username
+    mysql_password_secret_name = module.fleet.byo-vpc.secrets.secret_ids["${local.customer}-database-password"]
+    rds_security_group_id      = module.fleet.byo-vpc.rds.security_group_id
+    subnet_ids                 = module.fleet.vpc.private_subnets
+    vpc_id                     = module.fleet.vpc.vpc_id
     # Format of https://pkg.go.dev/time#ParseDuration
     delay_tolerance = "4h"
     # Interval format for: https://docs.aws.amazon.com/scheduler/latest/UserGuide/schedule-types.html#rate-based
@@ -78,6 +79,29 @@ module "monitoring" {
     log_retention_in_days = 365
     # Cron List of Names to Ignore (see below for valid values)
     ignore_list = []
+  }
+  log_monitoring = {
+    invalid-secret = {
+      log_group_name = module.fleet.byo-vpc.byo-db.byo-ecs.logging_config.awslogs-group
+      pattern = "{ $.internal = \"invalid secret\" }"
+      evaluation_periods = 1
+      period             = 3600
+      threshold          = 1
+    }
+    duplicate-identifier = {
+      log_group_name = module.fleet.byo-vpc.byo-db.byo-ecs.logging_config.awslogs-group
+      pattern = "{ $.msg = \"osquery host with duplicate identifier has enrolled in Fleet and will overwrite existing host data\" }"
+      evaluation_periods = 1
+      period             = 3600
+      threshold          = 1
+    }
+    limit-exceeded = {
+      log_group_name = module.fleet.byo-vpc.byo-db.byo-ecs.logging_config.awslogs-group
+      pattern = "{ $.err = \"limit exceeded\" }"
+      evaluation_periods = 1
+      period             = 60
+      threshold          = 1
+    }
   }
 }
 ```
@@ -92,6 +116,7 @@ Valid targets for `sns_topic_arns_map`:
  - backend_response_time
  - cron_monitoring (notifications about failures in the cron scheduler)
  - cron_job_failure_monitoring (notifications about errors in individual cron jobs - defaults to value of `cron_monitoring`)
+ - log_monitoring
  - rds_cpu_untilizaton_too_high
  - rds_db_event_subscription
  - redis_cpu_engine_utilization


### PR DESCRIPTION
Use module.fleet over module.main to reflect the reference architecture examples.