### PR TITLE
Add S3 bucket outputs for logging destination addons

### DIFF
--- a/addons/logging-destination-datadog/outputs.tf
+++ b/addons/logging-destination-datadog/outputs.tf
@@ -24,5 +24,5 @@ output "fleet_s3_datadog_failure_config" {
     bucket_name      = aws_s3_bucket.datadog-failure.bucket
     s3_object_prefix = var.s3_bucket_config.name_prefix
   }
-  description = "S3 bucket details"
+  description = "S3 bucket details - datadog-failure"
 }

--- a/addons/logging-destination-firehose/outputs.tf
+++ b/addons/logging-destination-firehose/outputs.tf
@@ -19,18 +19,21 @@ output "fleet_extra_iam_policies" {
 
 output "fleet_s3_firehose_osquery_results_config" {
   value = {
-    bucket_name      = aws_s3_bucket.osquery-results.bucket
+    bucket_name = aws_s3_bucket.osquery-results.bucket
   }
+  description = "S3 bucket details - osquery-results"
 }
 
 output "fleet_s3_firehose_osquery_status_config" {
   value = {
-    bucket_name      = aws_s3_bucket.osquery-status.bucket
+    bucket_name = aws_s3_bucket.osquery-status.bucket
   }
+  description = "S3 bucket details - osquery-status"
 }
 
 output "fleet_s3_firehose_audit_config" {
   value = {
-    bucket_name      = aws_s3_bucket.audit.bucket
+    bucket_name = aws_s3_bucket.audit.bucket
   }
+  description = "S3 bucket details - audit"
 }

--- a/addons/logging-destination-snowflake/outputs.tf
+++ b/addons/logging-destination-snowflake/outputs.tf
@@ -24,4 +24,5 @@ output "fleet_s3_snowflake_failure_config" {
     bucket_name      = aws_s3_bucket.snowflake-failure.bucket
     s3_object_prefix = var.s3_bucket_config.name_prefix
   }
+  description = "S3 bucket details - snowflake-failure"
 }


### PR DESCRIPTION
addons/logging-destination-datadog
- Adds `output.fleet_s3_datadog_failure_config`

addons/logging-destination-firehose
- Adds `output.fleet_s3_firehose_osquery_results_config`
- Adds `output.fleet_s3_firehose_osquery_status_config`
- Adds `output.fleet_s3_firehose_audit_config`

addons/logging-destination-snowflake
- Adds `output.fleet_s3_snowflake_failure_config`