### PR TITLE
Fix resource iam_role_name length limitations in logging-alb module

### DIFF
--- a/addons/logging-alb/.header.md
+++ b/addons/logging-alb/.header.md
@@ -36,7 +36,7 @@ module "main" {
 }
 
 module "logging_alb" {
-  source                 = "github.com/fleetdm/fleet-terraform//addons/logging-alb?ref=main"
+  source                 = "github.com/fleetdm/fleet-terraform//addons/logging-alb?ref=tf-mod-addon-logging-alb-v2.2.2"
   prefix                 = "fleet"
   enable_athena          = true
 

--- a/addons/logging-alb/.header.md
+++ b/addons/logging-alb/.header.md
@@ -1,11 +1,11 @@
 # ALB Logging Addon
-This addon creates an S3 bucket for ALB access logs with in-place SSE-KMS re-encryption via Lambda. ALB access logging requires SSE-S3 (AES256), so objects are written with SSE-S3 and immediately re-encrypted to SSE-KMS using a customer-managed KMS key. The same module-managed CMK also encrypts the Lambda functions and their CloudWatch log groups.
+This addon creates an S3 bucket for ALB access logs with optional in-place SSE-KMS re-encryption via Lambda. ALB access logging requires SSE-S3 (AES256), so objects are written with SSE-S3. When `enable_reencrypt_sweep` is enabled, objects are immediately re-encrypted to SSE-KMS using a customer-managed KMS key. The module-managed CMK also encrypts the Lambda functions and their CloudWatch log groups when the feature is active.
 
 ## How it works
 
 1. **ALB writes** log objects to the S3 bucket using SSE-S3 (the only encryption ALB supports).
-2. **Event-driven Lambda** triggers on `s3:ObjectCreated:Put` and re-encrypts each object in-place to SSE-KMS via `CopyObject`. The Lambda's `CopyObject` emits `s3:ObjectCreated:Copy` which does not re-trigger the notification (loop prevention).
-3. **Daily sweep Lambda** runs via EventBridge and scans the last 2 days of ALB log prefixes. If any SSE-S3 objects are found (missed by the event-driven Lambda), it generates a CSV manifest and submits an S3 Batch Operations `S3PutObjectCopy` job to re-encrypt them.
+2. **Event-driven Lambda** (optional, requires `enable_reencrypt_sweep = true`) triggers on `s3:ObjectCreated:Put` and re-encrypts each object in-place to SSE-KMS via `CopyObject`. The Lambda's `CopyObject` emits `s3:ObjectCreated:Copy` which does not re-trigger the notification (loop prevention).
+3. **Daily sweep Lambda** (optional, requires `enable_reencrypt_sweep = true`) runs via EventBridge and scans the last 2 days of ALB log prefixes. If any SSE-S3 objects are found (missed by the event-driven Lambda), it generates a CSV manifest and submits an S3 Batch Operations `S3PutObjectCopy` job to re-encrypt them.
 
 Optionally creates Athena resources for querying the logs.
 
@@ -36,9 +36,16 @@ module "main" {
 }
 
 module "logging_alb" {
-  source        = "github.com/fleetdm/fleet-terraform//addons/logging-alb?ref=main"
-  prefix        = "fleet"
-  enable_athena = true
+  source                 = "github.com/fleetdm/fleet-terraform//addons/logging-alb?ref=main"
+  prefix                 = "fleet"
+  enable_athena          = true
+
+  # Optional: Enable the re-encrypt and sweep Lambda functions and associated resources. Default: false
+  enable_reencrypt_sweep = true
+
+  # Optional: Override the prefix used in IAM role names when enable_reencrypt_sweep = true.
+  # Must be 16 characters or fewer.
+  # iam_role_name_prefix = "fleet"
 }
 ```
 
@@ -56,7 +63,7 @@ s3://your-alb-logs-bucket/<PREFIX>/AWSLogs/<ACCOUNT-ID>/elasticloadbalancing/<RE
 
 If upgrading from a previous version that used a separate archive bucket, use the provided script to re-encrypt existing SSE-S3 objects in-place. The script uses S3 Batch Operations with `S3PutObjectCopy` to re-encrypt objects at scale.
 
-1. Apply Terraform so the new Lambda functions and Batch Operations IAM role are in place.
+1. Apply Terraform with `enable_reencrypt_sweep = true` so the Lambda functions and Batch Operations IAM role are in place.
 2. Run the migration script to re-encrypt existing objects:
 
 ```

--- a/addons/logging-alb/.header.md
+++ b/addons/logging-alb/.header.md
@@ -41,7 +41,7 @@ module "logging_alb" {
   enable_athena          = true
 
   # Optional: Enable the re-encrypt and sweep Lambda functions and associated resources. Default: false
-  enable_reencrypt_sweep = true
+  # enable_reencrypt_sweep = true
 
   # Optional: Override the prefix used in IAM role names when enable_reencrypt_sweep = true.
   # Must be 16 characters or fewer.

--- a/addons/logging-alb/README.md
+++ b/addons/logging-alb/README.md
@@ -1,11 +1,11 @@
 # ALB Logging Addon
-This addon creates an S3 bucket for ALB access logs with in-place SSE-KMS re-encryption via Lambda. ALB access logging requires SSE-S3 (AES256), so objects are written with SSE-S3 and immediately re-encrypted to SSE-KMS using a customer-managed KMS key. The same module-managed CMK also encrypts the Lambda functions and their CloudWatch log groups.
+This addon creates an S3 bucket for ALB access logs with optional in-place SSE-KMS re-encryption via Lambda. ALB access logging requires SSE-S3 (AES256), so objects are written with SSE-S3. When `enable_reencrypt_sweep` is enabled, objects are immediately re-encrypted to SSE-KMS using a customer-managed KMS key. The module-managed CMK also encrypts the Lambda functions and their CloudWatch log groups when the feature is active.
 
 ## How it works
 
 1. **ALB writes** log objects to the S3 bucket using SSE-S3 (the only encryption ALB supports).
-2. **Event-driven Lambda** triggers on `s3:ObjectCreated:Put` and re-encrypts each object in-place to SSE-KMS via `CopyObject`. The Lambda's `CopyObject` emits `s3:ObjectCreated:Copy` which does not re-trigger the notification (loop prevention).
-3. **Daily sweep Lambda** runs via EventBridge and scans the last 2 days of ALB log prefixes. If any SSE-S3 objects are found (missed by the event-driven Lambda), it generates a CSV manifest and submits an S3 Batch Operations `S3PutObjectCopy` job to re-encrypt them.
+2. **Event-driven Lambda** (optional, requires `enable_reencrypt_sweep = true`) triggers on `s3:ObjectCreated:Put` and re-encrypts each object in-place to SSE-KMS via `CopyObject`. The Lambda's `CopyObject` emits `s3:ObjectCreated:Copy` which does not re-trigger the notification (loop prevention).
+3. **Daily sweep Lambda** (optional, requires `enable_reencrypt_sweep = true`) runs via EventBridge and scans the last 2 days of ALB log prefixes. If any SSE-S3 objects are found (missed by the event-driven Lambda), it generates a CSV manifest and submits an S3 Batch Operations `S3PutObjectCopy` job to re-encrypt them.
 
 Optionally creates Athena resources for querying the logs.
 
@@ -36,9 +36,16 @@ module "main" {
 }
 
 module "logging_alb" {
-  source        = "github.com/fleetdm/fleet-terraform//addons/logging-alb?ref=main"
-  prefix        = "fleet"
-  enable_athena = true
+  source                 = "github.com/fleetdm/fleet-terraform//addons/logging-alb?ref=main"
+  prefix                 = "fleet"
+  enable_athena          = true
+
+  # Optional: Enable the re-encrypt and sweep Lambda functions and associated resources. Default: false
+  enable_reencrypt_sweep = true
+
+  # Optional: Override the prefix used in IAM role names when enable_reencrypt_sweep = true.
+  # Must be 16 characters or fewer.
+  # iam_role_name_prefix = "fleet"
 }
 ```
 
@@ -56,7 +63,7 @@ s3://your-alb-logs-bucket/<PREFIX>/AWSLogs/<ACCOUNT-ID>/elasticloadbalancing/<RE
 
 If upgrading from a previous version that used a separate archive bucket, use the provided script to re-encrypt existing SSE-S3 objects in-place. The script uses S3 Batch Operations with `S3PutObjectCopy` to re-encrypt objects at scale.
 
-1. Apply Terraform so the new Lambda functions and Batch Operations IAM role are in place.
+1. Apply Terraform with `enable_reencrypt_sweep = true` so the Lambda functions and Batch Operations IAM role are in place.
 2. Run the migration script to re-encrypt existing objects:
 
 ```
@@ -84,14 +91,15 @@ No requirements.
 | Name | Version |
 |------|---------|
 | <a name="provider_archive"></a> [archive](#provider\_archive) | 2.7.1 |
-| <a name="provider_aws"></a> [aws](#provider\_aws) | 6.37.0 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | 6.40.0 |
+| <a name="provider_terraform"></a> [terraform](#provider\_terraform) | n/a |
 
 ## Modules
 
 | Name | Source | Version |
 |------|--------|---------|
-| <a name="module_athena-s3-bucket"></a> [athena-s3-bucket](#module\_athena-s3-bucket) | terraform-aws-modules/s3-bucket/aws | 5.0.0 |
-| <a name="module_s3_bucket_for_logs"></a> [s3\_bucket\_for\_logs](#module\_s3\_bucket\_for\_logs) | terraform-aws-modules/s3-bucket/aws | 5.0.0 |
+| <a name="module_athena-s3-bucket"></a> [athena-s3-bucket](#module\_athena-s3-bucket) | terraform-aws-modules/s3-bucket/aws | 5.12.0 |
+| <a name="module_s3_bucket_for_logs"></a> [s3\_bucket\_for\_logs](#module\_s3\_bucket\_for\_logs) | terraform-aws-modules/s3-bucket/aws | 5.12.0 |
 
 ## Resources
 
@@ -117,6 +125,7 @@ No requirements.
 | [aws_lambda_permission.eventbridge_invoke_sweep](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/lambda_permission) | resource |
 | [aws_lambda_permission.s3_invoke_reencrypt](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/lambda_permission) | resource |
 | [aws_s3_bucket_notification.reencrypt](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket_notification) | resource |
+| [terraform_data.validate_iam_prefix_length](https://registry.terraform.io/providers/hashicorp/terraform/latest/docs/resources/data) | resource |
 | [archive_file.lambda_reencrypt](https://registry.terraform.io/providers/hashicorp/archive/latest/docs/data-sources/file) | data source |
 | [archive_file.lambda_sweep](https://registry.terraform.io/providers/hashicorp/archive/latest/docs/data-sources/file) | data source |
 | [aws_caller_identity.current](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/caller_identity) | data source |
@@ -138,9 +147,11 @@ No requirements.
 |------|-------------|------|---------|:--------:|
 | <a name="input_alt_path_prefix"></a> [alt\_path\_prefix](#input\_alt\_path\_prefix) | Used if the prefix inside of the s3 bucket doesn't match the name of the bucket prefix | `string` | `null` | no |
 | <a name="input_enable_athena"></a> [enable\_athena](#input\_enable\_athena) | n/a | `bool` | `true` | no |
+| <a name="input_enable_reencrypt_sweep"></a> [enable\_reencrypt\_sweep](#input\_enable\_reencrypt\_sweep) | Enable the sweep and re-encrypt Lambda functions, EventBridge schedule, S3 bucket notification, and associated IAM roles. | `bool` | `false` | no |
 | <a name="input_extra_kms_policies"></a> [extra\_kms\_policies](#input\_extra\_kms\_policies) | n/a | `list(any)` | `[]` | no |
 | <a name="input_extra_s3_athena_policies"></a> [extra\_s3\_athena\_policies](#input\_extra\_s3\_athena\_policies) | n/a | `list(any)` | `[]` | no |
 | <a name="input_extra_s3_log_policies"></a> [extra\_s3\_log\_policies](#input\_extra\_s3\_log\_policies) | n/a | `list(any)` | `[]` | no |
+| <a name="input_iam_role_name_prefix"></a> [iam\_role\_name\_prefix](#input\_iam\_role\_name\_prefix) | Optional shorter prefix for IAM role name\_prefix fields, only used when enable\_reencrypt\_sweep = true (max 16 characters to fit within the 38-char AWS limit). Defaults to var.prefix. | `string` | `null` | no |
 | <a name="input_kms_base_policy"></a> [kms\_base\_policy](#input\_kms\_base\_policy) | Optional base KMS key-policy statements to apply to module-created CMKs before module-required service access statements are merged in. If null, the module defaults to the historical root `kms:*` statement. | <pre>list(object({<br/>    sid    = string<br/>    effect = string<br/>    principals = object({<br/>      type        = string<br/>      identifiers = list(string)<br/>    })<br/>    actions   = list(string)<br/>    resources = list(string)<br/>    conditions = optional(list(object({<br/>      test     = string<br/>      variable = string<br/>      values   = list(string)<br/>    })), [])<br/>  }))</pre> | `null` | no |
 | <a name="input_lambda_log_retention_in_days"></a> [lambda\_log\_retention\_in\_days](#input\_lambda\_log\_retention\_in\_days) | CloudWatch log retention in days for the re-encrypt and sweep Lambda functions | `number` | `365` | no |
 | <a name="input_prefix"></a> [prefix](#input\_prefix) | n/a | `string` | `"fleet"` | no |

--- a/addons/logging-alb/README.md
+++ b/addons/logging-alb/README.md
@@ -36,7 +36,7 @@ module "main" {
 }
 
 module "logging_alb" {
-  source                 = "github.com/fleetdm/fleet-terraform//addons/logging-alb?ref=main"
+  source                 = "github.com/fleetdm/fleet-terraform//addons/logging-alb?ref=tf-mod-addon-logging-alb-v2.2.2"
   prefix                 = "fleet"
   enable_athena          = true
 

--- a/addons/logging-alb/README.md
+++ b/addons/logging-alb/README.md
@@ -41,7 +41,7 @@ module "logging_alb" {
   enable_athena          = true
 
   # Optional: Enable the re-encrypt and sweep Lambda functions and associated resources. Default: false
-  enable_reencrypt_sweep = true
+  # enable_reencrypt_sweep = true
 
   # Optional: Override the prefix used in IAM role names when enable_reencrypt_sweep = true.
   # Must be 16 characters or fewer.

--- a/addons/logging-alb/main.tf
+++ b/addons/logging-alb/main.tf
@@ -1,4 +1,6 @@
 resource "terraform_data" "validate_iam_prefix_length" {
+  count = var.enable_reencrypt_sweep ? 1 : 0
+
   lifecycle {
     precondition {
       condition     = length(local.iam_role_prefix) <= 16
@@ -16,10 +18,10 @@ data "aws_region" "current" {}
 locals {
   iam_role_prefix     = coalesce(var.iam_role_name_prefix, var.prefix)
   landing_bucket_name = "${var.prefix}-alb-logs"
-  lambda_function_arns = [
+  lambda_function_arns = var.enable_reencrypt_sweep ? [
     "arn:${data.aws_partition.current.partition}:lambda:${data.aws_region.current.id}:${data.aws_caller_identity.current.account_id}:function:${var.prefix}-alb-log-reencrypt",
     "arn:${data.aws_partition.current.partition}:lambda:${data.aws_region.current.id}:${data.aws_caller_identity.current.account_id}:function:${var.prefix}-alb-log-sweep",
-  ]
+  ] : []
 
   kms_base_policy_statements = var.kms_base_policy != null ? var.kms_base_policy : [
     {
@@ -35,69 +37,75 @@ locals {
     }
   ]
 
-  kms_service_statements = [
-    {
-      sid       = "AllowLambdaReencryptUseOfTheKey"
-      effect    = "Allow"
-      actions   = ["kms:Encrypt", "kms:Decrypt", "kms:GenerateDataKey*", "kms:DescribeKey"]
-      resources = ["*"]
-      principals = {
-        type        = "AWS"
-        identifiers = [aws_iam_role.lambda_reencrypt.arn]
-      }
-      conditions = []
-    },
-    {
-      sid       = "AllowLambdaSweepUseOfTheKey"
-      effect    = "Allow"
-      actions   = ["kms:Encrypt", "kms:Decrypt", "kms:GenerateDataKey*", "kms:DescribeKey"]
-      resources = ["*"]
-      principals = {
-        type        = "AWS"
-        identifiers = [aws_iam_role.lambda_sweep.arn]
-      }
-      conditions = []
-    },
-    {
-      sid       = "AllowBatchReencryptUseOfTheKey"
-      effect    = "Allow"
-      actions   = ["kms:Encrypt", "kms:GenerateDataKey", "kms:GenerateDataKeyWithoutPlaintext", "kms:DescribeKey"]
-      resources = ["*"]
-      principals = {
-        type        = "AWS"
-        identifiers = [aws_iam_role.batch_reencrypt.arn]
-      }
-      conditions = []
-    },
-    {
-      sid       = "AllowCloudWatchLogsUseOfTheKey"
-      effect    = "Allow"
-      actions   = ["kms:Encrypt*", "kms:Decrypt*", "kms:ReEncrypt*", "kms:GenerateDataKey*", "kms:Describe*"]
-      resources = ["*"]
-      principals = {
-        type        = "Service"
-        identifiers = ["logs.${data.aws_region.current.id}.amazonaws.com"]
-      }
-      conditions = []
-    },
-    {
-      sid       = "AllowLambdaServiceUseOfTheKey"
-      effect    = "Allow"
-      actions   = ["kms:GenerateDataKey", "kms:Decrypt"]
-      resources = ["*"]
-      principals = {
-        type        = "Service"
-        identifiers = ["lambda.amazonaws.com"]
-      }
-      conditions = [
-        {
-          test     = "StringLike"
-          variable = "kms:EncryptionContext:aws:lambda:FunctionArn"
-          values   = local.lambda_function_arns
+  kms_service_statements = concat(
+    var.enable_reencrypt_sweep ? [
+      {
+        sid       = "AllowLambdaReencryptUseOfTheKey"
+        effect    = "Allow"
+        actions   = ["kms:Encrypt", "kms:Decrypt", "kms:GenerateDataKey*", "kms:DescribeKey"]
+        resources = ["*"]
+        principals = {
+          type        = "AWS"
+          identifiers = [aws_iam_role.lambda_reencrypt[0].arn]
         }
-      ]
-    }
-  ]
+        conditions = []
+      },
+      {
+        sid       = "AllowLambdaSweepUseOfTheKey"
+        effect    = "Allow"
+        actions   = ["kms:Encrypt", "kms:Decrypt", "kms:GenerateDataKey*", "kms:DescribeKey"]
+        resources = ["*"]
+        principals = {
+          type        = "AWS"
+          identifiers = [aws_iam_role.lambda_sweep[0].arn]
+        }
+        conditions = []
+      },
+      {
+        sid       = "AllowBatchReencryptUseOfTheKey"
+        effect    = "Allow"
+        actions   = ["kms:Encrypt", "kms:GenerateDataKey", "kms:GenerateDataKeyWithoutPlaintext", "kms:DescribeKey"]
+        resources = ["*"]
+        principals = {
+          type        = "AWS"
+          identifiers = [aws_iam_role.batch_reencrypt[0].arn]
+        }
+        conditions = []
+      },
+    ] : [],
+    [
+      {
+        sid       = "AllowCloudWatchLogsUseOfTheKey"
+        effect    = "Allow"
+        actions   = ["kms:Encrypt*", "kms:Decrypt*", "kms:ReEncrypt*", "kms:GenerateDataKey*", "kms:Describe*"]
+        resources = ["*"]
+        principals = {
+          type        = "Service"
+          identifiers = ["logs.${data.aws_region.current.id}.amazonaws.com"]
+        }
+        conditions = []
+      },
+    ],
+    var.enable_reencrypt_sweep ? [
+      {
+        sid       = "AllowLambdaServiceUseOfTheKey"
+        effect    = "Allow"
+        actions   = ["kms:GenerateDataKey", "kms:Decrypt"]
+        resources = ["*"]
+        principals = {
+          type        = "Service"
+          identifiers = ["lambda.amazonaws.com"]
+        }
+        conditions = [
+          {
+            test     = "StringLike"
+            variable = "kms:EncryptionContext:aws:lambda:FunctionArn"
+            values   = local.lambda_function_arns
+          }
+        ]
+      }
+    ] : [],
+  )
 
   s3_path_prefix = coalesce(var.alt_path_prefix, var.prefix)
 }
@@ -310,6 +318,8 @@ module "s3_bucket_for_logs" {
 # ── Event-driven re-encrypt Lambda ───────────────────────────────────────────
 
 data "aws_iam_policy_document" "lambda_reencrypt_assume_role" {
+  count = var.enable_reencrypt_sweep ? 1 : 0
+
   statement {
     actions = ["sts:AssumeRole"]
 
@@ -321,6 +331,8 @@ data "aws_iam_policy_document" "lambda_reencrypt_assume_role" {
 }
 
 data "aws_iam_policy_document" "lambda_reencrypt" {
+  count = var.enable_reencrypt_sweep ? 1 : 0
+
   statement {
     sid = "ReadWriteBucket"
     actions = [
@@ -339,43 +351,53 @@ data "aws_iam_policy_document" "lambda_reencrypt" {
       "logs:PutLogEvents",
     ]
     resources = [
-      "${aws_cloudwatch_log_group.lambda_reencrypt.arn}:*",
+      "${aws_cloudwatch_log_group.lambda_reencrypt[0].arn}:*",
     ]
   }
 }
 
 resource "aws_iam_role" "lambda_reencrypt" {
+  count = var.enable_reencrypt_sweep ? 1 : 0
+
   name_prefix        = "${local.iam_role_prefix}-alb-log-reencrypt-"
-  assume_role_policy = data.aws_iam_policy_document.lambda_reencrypt_assume_role.json
+  assume_role_policy = data.aws_iam_policy_document.lambda_reencrypt_assume_role[0].json
 }
 
 resource "aws_iam_role_policy" "lambda_reencrypt" {
+  count = var.enable_reencrypt_sweep ? 1 : 0
+
   name_prefix = "${local.iam_role_prefix}-alb-log-reencrypt-"
-  role        = aws_iam_role.lambda_reencrypt.id
-  policy      = data.aws_iam_policy_document.lambda_reencrypt.json
+  role        = aws_iam_role.lambda_reencrypt[0].id
+  policy      = data.aws_iam_policy_document.lambda_reencrypt[0].json
 }
 
 data "archive_file" "lambda_reencrypt" {
+  count = var.enable_reencrypt_sweep ? 1 : 0
+
   type        = "zip"
   source_file = "${path.module}/lambda/reencrypt.py"
   output_path = "${path.module}/lambda/.reencrypt.zip"
 }
 
 resource "aws_cloudwatch_log_group" "lambda_reencrypt" {
+  count = var.enable_reencrypt_sweep ? 1 : 0
+
   name              = "/aws/lambda/${var.prefix}-alb-log-reencrypt"
   kms_key_id        = aws_kms_key.logs.arn
   retention_in_days = var.lambda_log_retention_in_days
 }
 
 resource "aws_lambda_function" "reencrypt" {
+  count = var.enable_reencrypt_sweep ? 1 : 0
+
   function_name    = "${var.prefix}-alb-log-reencrypt"
-  role             = aws_iam_role.lambda_reencrypt.arn
+  role             = aws_iam_role.lambda_reencrypt[0].arn
   handler          = "reencrypt.handler"
   kms_key_arn      = aws_kms_key.logs.arn
   runtime          = "python3.12"
   timeout          = 60
-  filename         = data.archive_file.lambda_reencrypt.output_path
-  source_code_hash = data.archive_file.lambda_reencrypt.output_base64sha256
+  filename         = data.archive_file.lambda_reencrypt[0].output_path
+  source_code_hash = data.archive_file.lambda_reencrypt[0].output_base64sha256
 
   environment {
     variables = {
@@ -390,18 +412,22 @@ resource "aws_lambda_function" "reencrypt" {
 }
 
 resource "aws_lambda_permission" "s3_invoke_reencrypt" {
+  count = var.enable_reencrypt_sweep ? 1 : 0
+
   statement_id  = "AllowS3Invoke"
   action        = "lambda:InvokeFunction"
-  function_name = aws_lambda_function.reencrypt.function_name
+  function_name = aws_lambda_function.reencrypt[0].function_name
   principal     = "s3.amazonaws.com"
   source_arn    = module.s3_bucket_for_logs.s3_bucket_arn
 }
 
 resource "aws_s3_bucket_notification" "reencrypt" {
+  count = var.enable_reencrypt_sweep ? 1 : 0
+
   bucket = module.s3_bucket_for_logs.s3_bucket_id
 
   lambda_function {
-    lambda_function_arn = aws_lambda_function.reencrypt.arn
+    lambda_function_arn = aws_lambda_function.reencrypt[0].arn
     events              = ["s3:ObjectCreated:Put"]
     filter_prefix       = "${local.s3_path_prefix}/"
   }
@@ -412,6 +438,8 @@ resource "aws_s3_bucket_notification" "reencrypt" {
 # ── Sweep re-encrypt Lambda (daily) ─────────────────────────────────────────
 
 data "aws_iam_policy_document" "lambda_sweep_assume_role" {
+  count = var.enable_reencrypt_sweep ? 1 : 0
+
   statement {
     actions = ["sts:AssumeRole"]
 
@@ -423,6 +451,8 @@ data "aws_iam_policy_document" "lambda_sweep_assume_role" {
 }
 
 data "aws_iam_policy_document" "lambda_sweep" {
+  count = var.enable_reencrypt_sweep ? 1 : 0
+
   statement {
     sid = "ListBucket"
     actions = [
@@ -458,7 +488,7 @@ data "aws_iam_policy_document" "lambda_sweep" {
       "iam:PassRole",
     ]
     resources = [
-      aws_iam_role.batch_reencrypt.arn,
+      aws_iam_role.batch_reencrypt[0].arn,
     ]
   }
 
@@ -469,43 +499,53 @@ data "aws_iam_policy_document" "lambda_sweep" {
       "logs:PutLogEvents",
     ]
     resources = [
-      "${aws_cloudwatch_log_group.lambda_sweep.arn}:*",
+      "${aws_cloudwatch_log_group.lambda_sweep[0].arn}:*",
     ]
   }
 }
 
 resource "aws_iam_role" "lambda_sweep" {
+  count = var.enable_reencrypt_sweep ? 1 : 0
+
   name_prefix        = "${local.iam_role_prefix}-alb-log-sweep-"
-  assume_role_policy = data.aws_iam_policy_document.lambda_sweep_assume_role.json
+  assume_role_policy = data.aws_iam_policy_document.lambda_sweep_assume_role[0].json
 }
 
 resource "aws_iam_role_policy" "lambda_sweep" {
+  count = var.enable_reencrypt_sweep ? 1 : 0
+
   name_prefix = "${local.iam_role_prefix}-alb-log-sweep-"
-  role        = aws_iam_role.lambda_sweep.id
-  policy      = data.aws_iam_policy_document.lambda_sweep.json
+  role        = aws_iam_role.lambda_sweep[0].id
+  policy      = data.aws_iam_policy_document.lambda_sweep[0].json
 }
 
 data "archive_file" "lambda_sweep" {
+  count = var.enable_reencrypt_sweep ? 1 : 0
+
   type        = "zip"
   source_file = "${path.module}/lambda/sweep_reencrypt.py"
   output_path = "${path.module}/lambda/.sweep_reencrypt.zip"
 }
 
 resource "aws_cloudwatch_log_group" "lambda_sweep" {
+  count = var.enable_reencrypt_sweep ? 1 : 0
+
   name              = "/aws/lambda/${var.prefix}-alb-log-sweep"
   kms_key_id        = aws_kms_key.logs.arn
   retention_in_days = var.lambda_log_retention_in_days
 }
 
 resource "aws_lambda_function" "sweep_reencrypt" {
+  count = var.enable_reencrypt_sweep ? 1 : 0
+
   function_name    = "${var.prefix}-alb-log-sweep"
-  role             = aws_iam_role.lambda_sweep.arn
+  role             = aws_iam_role.lambda_sweep[0].arn
   handler          = "sweep_reencrypt.handler"
   kms_key_arn      = aws_kms_key.logs.arn
   runtime          = "python3.12"
   timeout          = 900
-  filename         = data.archive_file.lambda_sweep.output_path
-  source_code_hash = data.archive_file.lambda_sweep.output_base64sha256
+  filename         = data.archive_file.lambda_sweep[0].output_path
+  source_code_hash = data.archive_file.lambda_sweep[0].output_base64sha256
 
   environment {
     variables = {
@@ -514,7 +554,7 @@ resource "aws_lambda_function" "sweep_reencrypt" {
       LOG_PREFIX     = local.s3_path_prefix
       ACCOUNT_ID     = data.aws_caller_identity.current.account_id
       REGION         = data.aws_region.current.region
-      BATCH_ROLE_ARN = aws_iam_role.batch_reencrypt.arn
+      BATCH_ROLE_ARN = aws_iam_role.batch_reencrypt[0].arn
     }
   }
 
@@ -527,26 +567,34 @@ resource "aws_lambda_function" "sweep_reencrypt" {
 # ── EventBridge daily schedule → sweep Lambda ────────────────────────────────
 
 resource "aws_cloudwatch_event_rule" "sweep_reencrypt" {
+  count = var.enable_reencrypt_sweep ? 1 : 0
+
   name_prefix         = "${local.iam_role_prefix}-alb-log-sweep-"
   schedule_expression = "rate(1 day)"
 }
 
 resource "aws_cloudwatch_event_target" "sweep_reencrypt" {
-  rule = aws_cloudwatch_event_rule.sweep_reencrypt.name
-  arn  = aws_lambda_function.sweep_reencrypt.arn
+  count = var.enable_reencrypt_sweep ? 1 : 0
+
+  rule = aws_cloudwatch_event_rule.sweep_reencrypt[0].name
+  arn  = aws_lambda_function.sweep_reencrypt[0].arn
 }
 
 resource "aws_lambda_permission" "eventbridge_invoke_sweep" {
+  count = var.enable_reencrypt_sweep ? 1 : 0
+
   statement_id  = "AllowEventBridgeInvoke"
   action        = "lambda:InvokeFunction"
-  function_name = aws_lambda_function.sweep_reencrypt.function_name
+  function_name = aws_lambda_function.sweep_reencrypt[0].function_name
   principal     = "events.amazonaws.com"
-  source_arn    = aws_cloudwatch_event_rule.sweep_reencrypt.arn
+  source_arn    = aws_cloudwatch_event_rule.sweep_reencrypt[0].arn
 }
 
 # ── S3 Batch Operations IAM role (used by sweep Lambda and migration script) ─
 
 data "aws_iam_policy_document" "batch_reencrypt_assume_role" {
+  count = var.enable_reencrypt_sweep ? 1 : 0
+
   statement {
     actions = ["sts:AssumeRole"]
 
@@ -558,6 +606,8 @@ data "aws_iam_policy_document" "batch_reencrypt_assume_role" {
 }
 
 data "aws_iam_policy_document" "batch_reencrypt" {
+  count = var.enable_reencrypt_sweep ? 1 : 0
+
   statement {
     sid = "ReadWriteBucket"
     actions = [
@@ -572,14 +622,18 @@ data "aws_iam_policy_document" "batch_reencrypt" {
 }
 
 resource "aws_iam_role" "batch_reencrypt" {
+  count = var.enable_reencrypt_sweep ? 1 : 0
+
   name_prefix        = "${local.iam_role_prefix}-alb-batch-reencrypt-"
-  assume_role_policy = data.aws_iam_policy_document.batch_reencrypt_assume_role.json
+  assume_role_policy = data.aws_iam_policy_document.batch_reencrypt_assume_role[0].json
 }
 
 resource "aws_iam_role_policy" "batch_reencrypt" {
+  count = var.enable_reencrypt_sweep ? 1 : 0
+
   name_prefix = "${local.iam_role_prefix}-alb-batch-reencrypt-"
-  role        = aws_iam_role.batch_reencrypt.id
-  policy      = data.aws_iam_policy_document.batch_reencrypt.json
+  role        = aws_iam_role.batch_reencrypt[0].id
+  policy      = data.aws_iam_policy_document.batch_reencrypt[0].json
 }
 
 # ── Athena (optional) ────────────────────────────────────────────────────────

--- a/addons/logging-alb/main.tf
+++ b/addons/logging-alb/main.tf
@@ -1,3 +1,12 @@
+resource "terraform_data" "validate_iam_prefix_length" {
+  lifecycle {
+    precondition {
+      condition     = length(local.iam_role_prefix) <= 16
+      error_message = "The resolved IAM role name prefix '${local.iam_role_prefix}' is ${length(local.iam_role_prefix)} characters, but must be 16 or fewer. The longest suffix is '-alb-batch-reencrypt-' (22 chars) and AWS limits name_prefix to 38 characters. Set iam_role_name_prefix to a shorter value."
+    }
+  }
+}
+
 data "aws_caller_identity" "current" {}
 
 data "aws_partition" "current" {}
@@ -5,6 +14,7 @@ data "aws_partition" "current" {}
 data "aws_region" "current" {}
 
 locals {
+  iam_role_prefix     = coalesce(var.iam_role_name_prefix, var.prefix)
   landing_bucket_name = "${var.prefix}-alb-logs"
   lambda_function_arns = [
     "arn:${data.aws_partition.current.partition}:lambda:${data.aws_region.current.id}:${data.aws_caller_identity.current.account_id}:function:${var.prefix}-alb-log-reencrypt",
@@ -335,12 +345,12 @@ data "aws_iam_policy_document" "lambda_reencrypt" {
 }
 
 resource "aws_iam_role" "lambda_reencrypt" {
-  name_prefix        = "${var.prefix}-alb-log-reencrypt-"
+  name_prefix        = "${local.iam_role_prefix}-alb-log-reencrypt-"
   assume_role_policy = data.aws_iam_policy_document.lambda_reencrypt_assume_role.json
 }
 
 resource "aws_iam_role_policy" "lambda_reencrypt" {
-  name_prefix = "${var.prefix}-alb-log-reencrypt-"
+  name_prefix = "${local.iam_role_prefix}-alb-log-reencrypt-"
   role        = aws_iam_role.lambda_reencrypt.id
   policy      = data.aws_iam_policy_document.lambda_reencrypt.json
 }
@@ -465,12 +475,12 @@ data "aws_iam_policy_document" "lambda_sweep" {
 }
 
 resource "aws_iam_role" "lambda_sweep" {
-  name_prefix        = "${var.prefix}-alb-log-sweep-"
+  name_prefix        = "${local.iam_role_prefix}-alb-log-sweep-"
   assume_role_policy = data.aws_iam_policy_document.lambda_sweep_assume_role.json
 }
 
 resource "aws_iam_role_policy" "lambda_sweep" {
-  name_prefix = "${var.prefix}-alb-log-sweep-"
+  name_prefix = "${local.iam_role_prefix}-alb-log-sweep-"
   role        = aws_iam_role.lambda_sweep.id
   policy      = data.aws_iam_policy_document.lambda_sweep.json
 }
@@ -517,7 +527,7 @@ resource "aws_lambda_function" "sweep_reencrypt" {
 # ── EventBridge daily schedule → sweep Lambda ────────────────────────────────
 
 resource "aws_cloudwatch_event_rule" "sweep_reencrypt" {
-  name_prefix         = "${var.prefix}-alb-log-sweep-"
+  name_prefix         = "${local.iam_role_prefix}-alb-log-sweep-"
   schedule_expression = "rate(1 day)"
 }
 
@@ -562,12 +572,12 @@ data "aws_iam_policy_document" "batch_reencrypt" {
 }
 
 resource "aws_iam_role" "batch_reencrypt" {
-  name_prefix        = "${var.prefix}-alb-batch-reencrypt-"
+  name_prefix        = "${local.iam_role_prefix}-alb-batch-reencrypt-"
   assume_role_policy = data.aws_iam_policy_document.batch_reencrypt_assume_role.json
 }
 
 resource "aws_iam_role_policy" "batch_reencrypt" {
-  name_prefix = "${var.prefix}-alb-batch-reencrypt-"
+  name_prefix = "${local.iam_role_prefix}-alb-batch-reencrypt-"
   role        = aws_iam_role.batch_reencrypt.id
   policy      = data.aws_iam_policy_document.batch_reencrypt.json
 }

--- a/addons/logging-alb/main.tf
+++ b/addons/logging-alb/main.tf
@@ -37,75 +37,69 @@ locals {
     }
   ]
 
-  kms_service_statements = concat(
-    var.enable_reencrypt_sweep ? [
-      {
-        sid       = "AllowLambdaReencryptUseOfTheKey"
-        effect    = "Allow"
-        actions   = ["kms:Encrypt", "kms:Decrypt", "kms:GenerateDataKey*", "kms:DescribeKey"]
-        resources = ["*"]
-        principals = {
-          type        = "AWS"
-          identifiers = [aws_iam_role.lambda_reencrypt[0].arn]
-        }
-        conditions = []
-      },
-      {
-        sid       = "AllowLambdaSweepUseOfTheKey"
-        effect    = "Allow"
-        actions   = ["kms:Encrypt", "kms:Decrypt", "kms:GenerateDataKey*", "kms:DescribeKey"]
-        resources = ["*"]
-        principals = {
-          type        = "AWS"
-          identifiers = [aws_iam_role.lambda_sweep[0].arn]
-        }
-        conditions = []
-      },
-      {
-        sid       = "AllowBatchReencryptUseOfTheKey"
-        effect    = "Allow"
-        actions   = ["kms:Encrypt", "kms:GenerateDataKey", "kms:GenerateDataKeyWithoutPlaintext", "kms:DescribeKey"]
-        resources = ["*"]
-        principals = {
-          type        = "AWS"
-          identifiers = [aws_iam_role.batch_reencrypt[0].arn]
-        }
-        conditions = []
-      },
-    ] : [],
-    [
-      {
-        sid       = "AllowCloudWatchLogsUseOfTheKey"
-        effect    = "Allow"
-        actions   = ["kms:Encrypt*", "kms:Decrypt*", "kms:ReEncrypt*", "kms:GenerateDataKey*", "kms:Describe*"]
-        resources = ["*"]
-        principals = {
-          type        = "Service"
-          identifiers = ["logs.${data.aws_region.current.id}.amazonaws.com"]
-        }
-        conditions = []
-      },
-    ],
-    var.enable_reencrypt_sweep ? [
-      {
-        sid       = "AllowLambdaServiceUseOfTheKey"
-        effect    = "Allow"
-        actions   = ["kms:GenerateDataKey", "kms:Decrypt"]
-        resources = ["*"]
-        principals = {
-          type        = "Service"
-          identifiers = ["lambda.amazonaws.com"]
-        }
-        conditions = [
-          {
-            test     = "StringLike"
-            variable = "kms:EncryptionContext:aws:lambda:FunctionArn"
-            values   = local.lambda_function_arns
-          }
-        ]
+  kms_service_statements = var.enable_reencrypt_sweep ? [
+    {
+      sid       = "AllowLambdaReencryptUseOfTheKey"
+      effect    = "Allow"
+      actions   = ["kms:Encrypt", "kms:Decrypt", "kms:GenerateDataKey*", "kms:DescribeKey"]
+      resources = ["*"]
+      principals = {
+        type        = "AWS"
+        identifiers = [aws_iam_role.lambda_reencrypt[0].arn]
       }
-    ] : [],
-  )
+      conditions = []
+    },
+    {
+      sid       = "AllowLambdaSweepUseOfTheKey"
+      effect    = "Allow"
+      actions   = ["kms:Encrypt", "kms:Decrypt", "kms:GenerateDataKey*", "kms:DescribeKey"]
+      resources = ["*"]
+      principals = {
+        type        = "AWS"
+        identifiers = [aws_iam_role.lambda_sweep[0].arn]
+      }
+      conditions = []
+    },
+    {
+      sid       = "AllowBatchReencryptUseOfTheKey"
+      effect    = "Allow"
+      actions   = ["kms:Encrypt", "kms:GenerateDataKey", "kms:GenerateDataKeyWithoutPlaintext", "kms:DescribeKey"]
+      resources = ["*"]
+      principals = {
+        type        = "AWS"
+        identifiers = [aws_iam_role.batch_reencrypt[0].arn]
+      }
+      conditions = []
+    },
+    {
+      sid       = "AllowCloudWatchLogsUseOfTheKey"
+      effect    = "Allow"
+      actions   = ["kms:Encrypt*", "kms:Decrypt*", "kms:ReEncrypt*", "kms:GenerateDataKey*", "kms:Describe*"]
+      resources = ["*"]
+      principals = {
+        type        = "Service"
+        identifiers = ["logs.${data.aws_region.current.id}.amazonaws.com"]
+      }
+      conditions = []
+    },
+    {
+      sid       = "AllowLambdaServiceUseOfTheKey"
+      effect    = "Allow"
+      actions   = ["kms:GenerateDataKey", "kms:Decrypt"]
+      resources = ["*"]
+      principals = {
+        type        = "Service"
+        identifiers = ["lambda.amazonaws.com"]
+      }
+      conditions = [
+        {
+          test     = "StringLike"
+          variable = "kms:EncryptionContext:aws:lambda:FunctionArn"
+          values   = local.lambda_function_arns
+        }
+      ]
+    }
+  ] : []
 
   s3_path_prefix = coalesce(var.alt_path_prefix, var.prefix)
 }

--- a/addons/logging-alb/variables.tf
+++ b/addons/logging-alb/variables.tf
@@ -65,6 +65,17 @@ variable "kms_base_policy" {
   description = "Optional base KMS key-policy statements to apply to module-created CMKs before module-required service access statements are merged in. If null, the module defaults to the historical root `kms:*` statement."
 }
 
+variable "iam_role_name_prefix" {
+  description = "Optional shorter prefix for IAM role name_prefix fields (max 16 characters to fit within the 38-char AWS limit). Defaults to var.prefix."
+  type        = string
+  default     = null
+
+  validation {
+    condition     = var.iam_role_name_prefix == null || length(var.iam_role_name_prefix) <= 16
+    error_message = "iam_role_name_prefix must be 16 characters or fewer. The longest IAM role suffix is '-alb-batch-reencrypt-' (22 chars), and AWS limits name_prefix to 38 characters."
+  }
+}
+
 variable "extra_s3_log_policies" {
   type    = list(any)
   default = []

--- a/addons/logging-alb/variables.tf
+++ b/addons/logging-alb/variables.tf
@@ -69,11 +69,6 @@ variable "iam_role_name_prefix" {
   description = "Optional shorter prefix for IAM role name_prefix fields, only used when enable_reencrypt_sweep = true (max 16 characters to fit within the 38-char AWS limit). Defaults to var.prefix."
   type        = string
   default     = null
-
-  validation {
-    condition     = var.iam_role_name_prefix == null || length(var.iam_role_name_prefix) <= 16
-    error_message = "iam_role_name_prefix must be 16 characters or fewer. The longest IAM role suffix is '-alb-batch-reencrypt-' (22 chars), and AWS limits name_prefix to 38 characters."
-  }
 }
 
 variable "enable_reencrypt_sweep" {

--- a/addons/logging-alb/variables.tf
+++ b/addons/logging-alb/variables.tf
@@ -66,7 +66,7 @@ variable "kms_base_policy" {
 }
 
 variable "iam_role_name_prefix" {
-  description = "Optional shorter prefix for IAM role name_prefix fields (max 16 characters to fit within the 38-char AWS limit). Defaults to var.prefix."
+  description = "Optional shorter prefix for IAM role name_prefix fields, only used when enable_reencrypt_sweep = true (max 16 characters to fit within the 38-char AWS limit). Defaults to var.prefix."
   type        = string
   default     = null
 
@@ -74,6 +74,12 @@ variable "iam_role_name_prefix" {
     condition     = var.iam_role_name_prefix == null || length(var.iam_role_name_prefix) <= 16
     error_message = "iam_role_name_prefix must be 16 characters or fewer. The longest IAM role suffix is '-alb-batch-reencrypt-' (22 chars), and AWS limits name_prefix to 38 characters."
   }
+}
+
+variable "enable_reencrypt_sweep" {
+  description = "Enable the sweep and re-encrypt Lambda functions, EventBridge schedule, S3 bucket notification, and associated IAM roles."
+  type        = bool
+  default     = false
 }
 
 variable "extra_s3_log_policies" {


### PR DESCRIPTION
- Adds `var.enable_reencrypt_sweep` to control when lambda functions and permission resources should be created.
- Adds `var.iam_role_name_prefix` to allow overriding the prefix used for iam_role naming, when `var.enable_reencrypt_sweep = true`