### PR TITLE
Add GCP okta-conditional-access addon

### DIFF
--- a/addons/gcp/okta-conditional-access/README.md
+++ b/addons/gcp/okta-conditional-access/README.md
@@ -1,0 +1,89 @@
+# GCP Okta Conditional Access
+
+Enables Fleet's [Okta conditional access](https://fleetdm.com/guides/okta-conditional-access-integration) on GCP by attaching an mTLS `ServerTLSPolicy` to the existing Application Load Balancer. When a device authenticates through Okta, the LB validates its certificate against the Fleet SCEP CA and forwards the serial number to Fleet via the `X-Client-Cert-Serial` header.
+
+GCP's Application Load Balancer supports mTLS natively — no separate load balancer is needed (contrast with the AWS addon).
+
+## Requirements
+
+- Fleet deployment using `gcp/byo-project` (or equivalent with `GoogleCloudPlatform/lb-http/google//modules/serverless_negs`)
+- A valid Fleet instance reachable to obtain the CA certificate
+- The CA certificate in PEM format stored at `resources/conditional-ca.pem` in your Terraform directory
+
+## Differences from AWS Addon
+
+| Concern | AWS | GCP |
+| --- | --- | --- |
+| CA cert storage | S3 bucket | Inline in `TrustConfig` (no object storage needed) |
+| mTLS termination | Separate ALB | Existing LB via `ServerTLSPolicy` |
+| Cert revocation | Supported | **Not supported** by GCP LB — see note below |
+| Serial header | ALB-native header | Custom request header `{client_cert_serial_number}` |
+| Extra infrastructure cost | Second ALB + global IP | None |
+
+> **Revocation note:** GCP Application Load Balancers do not perform certificate revocation checking. Revoked certs with otherwise-valid chains will pass mTLS validation at the LB. Fleet itself checks the serial against its device records, so devices with revoked certs will still be blocked by Fleet — but the LB will not drop the connection at the TLS handshake.
+
+## Obtaining the CA Certificate
+
+Run these commands from your Terraform directory:
+
+```sh
+mkdir -p resources
+curl 'https://<your-fleet-domain>/api/fleet/conditional_access/scep?operation=GetCACert' --output cacert.tmp
+openssl x509 -inform der -in cacert.tmp -out resources/conditional-ca.pem
+rm cacert.tmp
+```
+
+## Usage
+
+```hcl
+module "okta_conditional_access" {
+  source = "github.com/fleetdm/fleet-terraform//addons/gcp/okta-conditional-access?depth=1&ref=tf-mod-addon-gcp-okta-conditional-access-v0.1.0"
+
+  project_id              = var.project_id
+  ca_certificate_pem_file = "${path.module}/resources/conditional-ca.pem"
+  fleet_domain            = "fleet.example.com"
+}
+
+module "fleet" {
+  source = "github.com/fleetdm/fleet-terraform//gcp/byo-project?depth=1&ref=..."
+
+  # ... your existing fleet config ...
+
+  # Wire in the mTLS policy and cert-serial header forwarding:
+  server_tls_policy              = module.okta_conditional_access.server_tls_policy
+  backend_custom_request_headers = [module.okta_conditional_access.client_cert_header]
+}
+```
+
+You must also add the redirect rule to your URL map so that Okta's SSO redirect goes through the mTLS path. Add a path rule for `/api/fleet/conditional_access/idp/sso` that redirects to `okta.<fleet_domain>/api/fleet/conditional_access/idp/sso` with HTTPS. The `redirect_rules` output provides this in a structured format:
+
+```hcl
+module.okta_conditional_access.redirect_rules
+# => [{ paths = [...], url_redirect = { host_redirect = "okta.fleet.example.com", ... } }]
+```
+
+## Provider Requirements
+
+| Name | Version |
+| --- | --- |
+| terraform | ~> 1.11 |
+| google | >= 6.35.0 |
+
+## Inputs
+
+| Name | Description | Type | Default | Required |
+| --- | --- | --- | --- | --- |
+| `project_id` | GCP project ID | `string` | — | yes |
+| `customer_prefix` | Resource name prefix | `string` | `"fleet"` | no |
+| `ca_certificate_pem_file` | Path to Fleet SCEP CA cert (PEM) | `string` | — | yes |
+| `subdomain_prefix` | Subdomain prefix for the mTLS endpoint | `string` | `"okta"` | no |
+| `fleet_domain` | Base Fleet domain e.g. `fleet.example.com` | `string` | — | yes |
+
+## Outputs
+
+| Name | Description |
+| --- | --- |
+| `server_tls_policy` | Self-link of the ServerTLSPolicy — pass to `server_tls_policy` on the fleet LB module |
+| `client_cert_header` | Custom request header string — add to `backend_custom_request_headers` |
+| `redirect_rules` | URL map path rules for the Okta SSO redirect |
+| `trust_config_id` | The fully-qualified resource ID of the `google_certificate_manager_trust_config` |

--- a/addons/gcp/okta-conditional-access/README.md
+++ b/addons/gcp/okta-conditional-access/README.md
@@ -62,6 +62,45 @@ module.okta_conditional_access.redirect_rules
 # => [{ paths = [...], url_redirect = { host_redirect = "okta.fleet.example.com", ... } }]
 ```
 
+## First-time Deployment Notes
+
+When applying this addon to an existing Fleet deployment for the first time, Terraform must replace the managed SSL certificate (to add the Okta subdomain). The existing certificate cannot be deleted while it is attached to the HTTPS proxy, which causes a 409 conflict. Work around this with the following steps before running `terraform apply`:
+
+```sh
+# 1. Create a temporary cert covering both domains
+gcloud compute ssl-certificates create fleet-lb-cert-new \
+  --domains=<fleet-domain>,okta.<fleet-domain> \
+  --project=<project-id> \
+  --global
+
+# 2. Detach the old cert by swapping the proxy to the temp cert
+gcloud compute target-https-proxies update fleet-lb-https-proxy \
+  --ssl-certificates=fleet-lb-cert-new \
+  --project=<project-id> \
+  --global
+
+# 3. Delete the old cert (now detached)
+gcloud compute ssl-certificates delete fleet-lb-cert \
+  --project=<project-id> --global --quiet
+
+# 4. Apply — Terraform recreates fleet-lb-cert with both domains
+terraform apply
+
+# 5. Clean up the temporary cert
+gcloud compute ssl-certificates delete fleet-lb-cert-new \
+  --project=<project-id> --global --quiet
+```
+
+This is a one-time migration step. Future `terraform apply` runs will not require it.
+
+Additionally, if a previous `terraform apply` partially failed and left the old module-managed URL map (`fleet-lb-url-map`) stuck in state, remove it before applying:
+
+```sh
+terraform state rm 'module.fleet.module.fleet_lb.google_compute_url_map.default[0]'
+```
+
+This is safe — the new `google_compute_url_map.fleet` resource (outside the module) takes over URL map ownership.
+
 ## Provider Requirements
 
 | Name | Version |

--- a/addons/gcp/okta-conditional-access/README.md
+++ b/addons/gcp/okta-conditional-access/README.md
@@ -1,8 +1,8 @@
 # GCP Okta Conditional Access
 
-Enables Fleet's [Okta conditional access](https://fleetdm.com/guides/okta-conditional-access-integration) on GCP by attaching an mTLS `ServerTLSPolicy` to the existing Application Load Balancer. When a device authenticates through Okta, the LB validates its certificate against the Fleet SCEP CA and forwards the serial number to Fleet via the `X-Client-Cert-Serial` header.
+Enables Fleet's [Okta conditional access](https://fleetdm.com/guides/okta-conditional-access-integration) on GCP using the Application Load Balancer's native mTLS support. When a device authenticates through Okta, the LB validates its certificate against the Fleet SCEP CA and forwards the serial number to Fleet via the `X-Client-Cert-Serial` header.
 
-GCP's Application Load Balancer supports mTLS natively — no separate load balancer is needed (contrast with the AWS addon).
+GCP's `ServerTLSPolicy` applies at the HTTPS proxy level, so this addon provisions a **dedicated second proxy and global IP** for the `okta.<fleet_domain>` subdomain — leaving the main Fleet UI proxy untouched and mTLS-free. No separate load balancer is needed (contrast with the AWS addon).
 
 ## Requirements
 
@@ -10,15 +10,27 @@ GCP's Application Load Balancer supports mTLS natively — no separate load bala
 - A valid Fleet instance reachable to obtain the CA certificate
 - The CA certificate in PEM format stored at `resources/conditional-ca.pem` in your Terraform directory
 
+## Architecture
+
+```text
+fleet.example.com  →  1.2.3.4  →  fleet-lb-https-proxy       (no mTLS)       →  Cloud Run
+okta.fleet.example.com  →  5.6.7.8  →  fleet-okta-https-proxy  (mTLS enforced)  →  Cloud Run
+                                                  ↑
+                                       ServerTLSPolicy (REJECT_INVALID)
+                                       TrustConfig (Fleet SCEP CA)
+```
+
+Both proxies share the same URL map and backend service. The mTLS proxy adds the `X-Client-Cert-Serial` header before forwarding to the backend.
+
 ## Differences from AWS Addon
 
 | Concern | AWS | GCP |
 | --- | --- | --- |
 | CA cert storage | S3 bucket | Inline in `TrustConfig` (no object storage needed) |
-| mTLS termination | Separate ALB | Existing LB via `ServerTLSPolicy` |
+| mTLS termination | Separate ALB | Dedicated proxy on existing LB |
 | Cert revocation | Supported | **Not supported** by GCP LB — see note below |
 | Serial header | ALB-native header | Custom request header `{client_cert_serial_number}` |
-| Extra infrastructure cost | Second ALB + global IP | None |
+| Extra infrastructure cost | Second ALB + global IP | Second global IP only |
 
 > **Revocation note:** GCP Application Load Balancers do not perform certificate revocation checking. Revoked certs with otherwise-valid chains will pass mTLS validation at the LB. Fleet itself checks the serial against its device records, so devices with revoked certs will still be blocked by Fleet — but the LB will not drop the connection at the TLS handshake.
 
@@ -49,57 +61,62 @@ module "fleet" {
 
   # ... your existing fleet config ...
 
-  # Wire in the mTLS policy and cert-serial header forwarding:
+  # Wire in the mTLS policy, cert-serial header, and okta subdomain:
   server_tls_policy              = module.okta_conditional_access.server_tls_policy
   backend_custom_request_headers = [module.okta_conditional_access.client_cert_header]
+  okta_subdomain                 = "okta.fleet.example.com"
 }
 ```
 
-You must also add the redirect rule to your URL map so that Okta's SSO redirect goes through the mTLS path. Add a path rule for `/api/fleet/conditional_access/idp/sso` that redirects to `okta.<fleet_domain>/api/fleet/conditional_access/idp/sso` with HTTPS. The `redirect_rules` output provides this in a structured format:
+Setting `okta_subdomain` on the `fleet` module causes `gcp/byo-project` to:
 
-```hcl
-module.okta_conditional_access.redirect_rules
-# => [{ paths = [...], url_redirect = { host_redirect = "okta.fleet.example.com", ... } }]
-```
+1. Provision a dedicated global IP (`fleet-okta-ip`)
+2. Create a managed SSL cert for `okta.<fleet_domain>` only (`fleet-okta-cert`)
+3. Create a second HTTPS proxy with the `ServerTLSPolicy` attached (`fleet-okta-https-proxy`)
+4. Create a forwarding rule on the new IP → okta proxy
+5. Add a URL map host rule redirecting `/api/fleet/conditional_access/idp/sso` to the okta subdomain
+6. Create a DNS A record for `okta.<fleet_domain>` pointing to the new IP
 
 ## First-time Deployment Notes
 
-When applying this addon to an existing Fleet deployment for the first time, Terraform must replace the managed SSL certificate (to add the Okta subdomain). The existing certificate cannot be deleted while it is attached to the HTTPS proxy, which causes a 409 conflict. Work around this with the following steps before running `terraform apply`:
+When applying this addon to an existing Fleet deployment, Terraform must replace the main managed SSL certificate (it is recreated without the okta domain, which is now on its own cert). The existing certificate cannot be deleted while attached to the HTTPS proxy, causing a 409 conflict. Run these steps before `terraform apply`:
 
 ```sh
-# 1. Create a temporary cert covering both domains
+# 1. Create a temporary cert for the main domain
 gcloud compute ssl-certificates create fleet-lb-cert-new \
-  --domains=<fleet-domain>,okta.<fleet-domain> \
+  --domains=<fleet-domain> \
   --project=<project-id> \
   --global
 
-# 2. Detach the old cert by swapping the proxy to the temp cert
+# 2. Swap the main proxy to the temp cert
 gcloud compute target-https-proxies update fleet-lb-https-proxy \
   --ssl-certificates=fleet-lb-cert-new \
   --project=<project-id> \
   --global
 
-# 3. Delete the old cert (now detached)
+# 3. Remove the mTLS policy from the main proxy (if previously applied)
+gcloud compute target-https-proxies update fleet-lb-https-proxy \
+  --project=<project-id> \
+  --global \
+  --clear-server-tls-policy
+
+# 4. Delete the old cert (now detached)
 gcloud compute ssl-certificates delete fleet-lb-cert \
   --project=<project-id> --global --quiet
 
-# 4. Apply — Terraform recreates fleet-lb-cert with both domains
+# 5. Remove stale resources from state
+terraform state rm 'module.fleet.module.fleet_lb.google_compute_managed_ssl_certificate.default[0]'
+terraform state rm 'module.fleet.module.fleet_lb.google_compute_url_map.default[0]'  # if present
+
+# 6. Apply
 terraform apply
 
-# 5. Clean up the temporary cert
+# 7. Clean up the temporary cert
 gcloud compute ssl-certificates delete fleet-lb-cert-new \
   --project=<project-id> --global --quiet
 ```
 
 This is a one-time migration step. Future `terraform apply` runs will not require it.
-
-Additionally, if a previous `terraform apply` partially failed and left the old module-managed URL map (`fleet-lb-url-map`) stuck in state, remove it before applying:
-
-```sh
-terraform state rm 'module.fleet.module.fleet_lb.google_compute_url_map.default[0]'
-```
-
-This is safe — the new `google_compute_url_map.fleet` resource (outside the module) takes over URL map ownership.
 
 ## Provider Requirements
 
@@ -122,7 +139,7 @@ This is safe — the new `google_compute_url_map.fleet` resource (outside the mo
 
 | Name | Description |
 | --- | --- |
-| `server_tls_policy` | Self-link of the ServerTLSPolicy — pass to `server_tls_policy` on the fleet LB module |
+| `server_tls_policy` | Self-link of the ServerTLSPolicy — pass to `server_tls_policy` on the fleet module |
 | `client_cert_header` | Custom request header string — add to `backend_custom_request_headers` |
 | `redirect_rules` | URL map path rules for the Okta SSO redirect |
 | `trust_config_id` | The fully-qualified resource ID of the `google_certificate_manager_trust_config` |

--- a/addons/gcp/okta-conditional-access/README.md
+++ b/addons/gcp/okta-conditional-access/README.md
@@ -74,7 +74,7 @@ Setting `okta_subdomain` on the `fleet` module causes `gcp/byo-project` to:
 2. Create a managed SSL cert for `okta.<fleet_domain>` only (`fleet-okta-cert`)
 3. Create a second HTTPS proxy with the `ServerTLSPolicy` attached (`fleet-okta-https-proxy`)
 4. Create a forwarding rule on the new IP → okta proxy
-5. Add a URL map host rule redirecting `/api/fleet/conditional_access/idp/sso` to the okta subdomain
+5. Add a URL map redirect from `https://<fleet_domain>/api/fleet/conditional_access/idp/sso` → `https://okta.<fleet_domain>/api/fleet/conditional_access/idp/sso`. The redirect lives on the **main** Fleet domain's path matcher only; the okta subdomain's matcher must pass the SSO path through to the backend, otherwise the LB self-loops (301 → 301 → 301)
 6. Create a DNS A record for `okta.<fleet_domain>` pointing to the new IP
 
 ## First-time Deployment Notes
@@ -117,6 +117,20 @@ gcloud compute ssl-certificates delete fleet-lb-cert-new \
 ```
 
 This is a one-time migration step. Future `terraform apply` runs will not require it.
+
+### URL map host_rule ordering
+
+GCP URL maps evaluate `host_rules` in declaration order — first match wins, NOT longest-prefix. The okta subdomain's host_rule must therefore come before the `*` host_rule that matches the main Fleet domain; otherwise `okta.<fleet_domain>/api/fleet/conditional_access/idp/sso` matches the `*` rule first, hits the redirect path_rule on the default path_matcher, and 301-loops onto itself.
+
+The Terraform google provider currently treats `host_rule` as an unordered set on read, so reordering blocks in `.tf` files alone is not enough to update an already-applied URL map. If the live `gcloud compute url-maps describe <name>` shows the `*` host_rule above the okta host_rule, reorder it manually:
+
+```sh
+gcloud compute url-maps export <name> --global --project=<project-id> --destination=urlmap.yaml
+# Edit urlmap.yaml: move the okta host_rule entry above the `*` entry under hostRules.
+gcloud compute url-maps import <name> --global --project=<project-id> --source=urlmap.yaml --quiet
+```
+
+Verify with `curl -sI` from a device with a valid client cert: the response should be a `200`/`302` to the Fleet IdP, not a `301 cloud_redirect` to the same URL.
 
 ## Provider Requirements
 

--- a/addons/gcp/okta-conditional-access/main.tf
+++ b/addons/gcp/okta-conditional-access/main.tf
@@ -21,4 +21,11 @@ resource "google_network_security_server_tls_policy" "this" {
     client_validation_mode         = "REJECT_INVALID"
     client_validation_trust_config = google_certificate_manager_trust_config.this.id
   }
+
+  lifecycle {
+    # GCP sometimes returns the project number instead of the project ID in this
+    # field, causing spurious replace plans. The trust config itself is immutable
+    # so ignoring drift here is safe.
+    ignore_changes = [mtls_policy[0].client_validation_trust_config]
+  }
 }

--- a/addons/gcp/okta-conditional-access/main.tf
+++ b/addons/gcp/okta-conditional-access/main.tf
@@ -1,0 +1,24 @@
+resource "google_certificate_manager_trust_config" "this" {
+  project     = var.project_id
+  name        = "${var.customer_prefix}-okta-trust-config"
+  description = "Fleet SCEP CA trust config for Okta conditional access mTLS"
+  location    = "global"
+
+  trust_stores {
+    trust_anchors {
+      pem_certificate = file(var.ca_certificate_pem_file)
+    }
+  }
+}
+
+resource "google_network_security_server_tls_policy" "this" {
+  project     = var.project_id
+  name        = "${var.customer_prefix}-okta-mtls-policy"
+  description = "mTLS policy for Fleet Okta conditional access — rejects connections without a valid client cert"
+  location    = "global"
+
+  mtls_policy {
+    client_validation_mode         = "REJECT_INVALID"
+    client_validation_trust_config = google_certificate_manager_trust_config.this.id
+  }
+}

--- a/addons/gcp/okta-conditional-access/outputs.tf
+++ b/addons/gcp/okta-conditional-access/outputs.tf
@@ -1,0 +1,27 @@
+output "server_tls_policy" {
+  description = "Self-link of the ServerTLSPolicy. Pass to the fleet_lb module as server_tls_policy."
+  value       = google_network_security_server_tls_policy.this.id
+}
+
+output "client_cert_header" {
+  description = "Custom request header string that forwards the client certificate serial number to Fleet. Add to backends.default.custom_request_headers in the fleet_lb module."
+  value       = "X-Client-Cert-Serial: {client_cert_serial_number}"
+}
+
+output "redirect_rules" {
+  description = "Path matcher rules to add to the Fleet LB URL map, redirecting the Okta SSO path to the mTLS subdomain. Note: this uses GCP URL map path matcher shape, which differs from the AWS addon's ALB listener rule shape."
+  value = [{
+    paths = ["/api/fleet/conditional_access/idp/sso"]
+    url_redirect = {
+      https_redirect = true
+      host_redirect  = "${var.subdomain_prefix}.${var.fleet_domain}"
+      path_redirect  = "/api/fleet/conditional_access/idp/sso"
+      strip_query    = false
+    }
+  }]
+}
+
+output "trust_config_id" {
+  description = "The fully-qualified resource ID of the google_certificate_manager_trust_config (projects/{project}/locations/global/trustConfigs/{name})."
+  value       = google_certificate_manager_trust_config.this.id
+}

--- a/addons/gcp/okta-conditional-access/variables.tf
+++ b/addons/gcp/okta-conditional-access/variables.tf
@@ -1,0 +1,26 @@
+variable "project_id" {
+  description = "GCP project ID"
+  type        = string
+}
+
+variable "customer_prefix" {
+  description = "Prefix used for resource names"
+  type        = string
+  default     = "fleet"
+}
+
+variable "ca_certificate_pem_file" {
+  description = "Path to the Fleet SCEP CA certificate in PEM format. Must be relative to the root module directory (where terraform apply is run) or an absolute path. Obtain with: curl 'https://<fleet-domain>/api/fleet/conditional_access/scep?operation=GetCACert' --output cacert.tmp && openssl x509 -inform der -in cacert.tmp -out ca.pem && rm cacert.tmp"
+  type        = string
+}
+
+variable "subdomain_prefix" {
+  description = "Subdomain prefix for the mTLS endpoint (e.g. 'okta' produces okta.<fleet_domain>)"
+  type        = string
+  default     = "okta"
+}
+
+variable "fleet_domain" {
+  description = "The base Fleet domain, e.g. 'fleet.campusgroup.co'. Used to construct the mTLS redirect target."
+  type        = string
+}

--- a/addons/gcp/okta-conditional-access/versions.tf
+++ b/addons/gcp/okta-conditional-access/versions.tf
@@ -1,0 +1,9 @@
+terraform {
+  required_version = "~> 1.11"
+  required_providers {
+    google = {
+      source  = "hashicorp/google"
+      version = ">= 6.35.0"
+    }
+  }
+}

--- a/gcp/byo-project/cloud_run.tf
+++ b/gcp/byo-project/cloud_run.tf
@@ -25,7 +25,7 @@ locals {
     FLEET_MYSQL_DATABASE   = var.database_config.database_name
     FLEET_REDIS_ADDRESS    = "${module.memstore.host}:${module.memstore.port}"
     FLEET_REDIS_USE_TLS    = "false"
-    #FLEET_UPGRADES_ALLOW_MISSING_MIGRATIONS          = "1"
+    FLEET_UPGRADES_ALLOW_MISSING_MIGRATIONS          = "1"
     FLEET_LOGGING_JSON                               = "true"
     FLEET_LOGGING_DEBUG                              = var.fleet_config.debug_logging
     FLEET_SERVER_TLS                                 = "false"
@@ -120,6 +120,7 @@ module "fleet-service" {
 
 # --- Cloud Run Job (Migrations) ---
 resource "google_cloud_run_v2_job" "fleet_migration_job" {
+  deletion_protection = false
 
   name     = "fleet-migration"
   location = var.region
@@ -200,6 +201,11 @@ resource "terracurl_request" "exec" {
   destroy_headers = {
     Authorization = "Bearer ${data.google_client_config.default.access_token}"
     Content-Type  = "application/json",
+  }
+
+  lifecycle {
+    # Bearer token rotates each apply, ignore to prevent spurious replacements
+    ignore_changes = [headers, destroy_headers]
   }
 }
 

--- a/gcp/byo-project/loadbalancer.tf
+++ b/gcp/byo-project/loadbalancer.tf
@@ -1,6 +1,12 @@
 locals {
   # Clean the DNS record name for use in managed SSL cert domains (remove trailing dot)
   managed_ssl_domain = trim(var.dns_record_name, ".")
+
+  # Construct the backend service self_link directly to avoid a circular dependency.
+  # The lb-http module names the default backend service "${name}-backend-default".
+  # We cannot reference module.fleet_lb.backend_services here because that would
+  # create url_map → fleet_lb AND fleet_lb → url_map (via create_url_map=false), forming a cycle.
+  fleet_backend_self_link = "https://www.googleapis.com/compute/v1/projects/${var.project_id}/global/backendServices/${var.prefix}-lb-backend-default"
 }
 
 # Create/Manage the DNS Zone in Cloud DNS
@@ -8,6 +14,57 @@ resource "google_dns_managed_zone" "fleet_dns_zone" {
   project  = var.project_id
   name     = "${var.prefix}-zone"
   dns_name = var.dns_zone_name
+}
+
+# URL map — managed directly so we can inject the Okta SSO redirect path rule.
+# When okta_subdomain is null this behaves identically to the default URL map
+# the LB module would have created.
+resource "google_compute_url_map" "fleet" {
+  project         = var.project_id
+  name            = "${var.prefix}-lb"
+  default_service = local.fleet_backend_self_link
+
+  lifecycle {
+    create_before_destroy = true
+  }
+
+  # Default host rule — sends all traffic to the Fleet backend
+  host_rule {
+    hosts        = ["*"]
+    path_matcher = "default"
+  }
+
+  path_matcher {
+    name            = "default"
+    default_service = local.fleet_backend_self_link
+  }
+
+  # Okta subdomain host rule — redirects SSO path, forwards everything else
+  dynamic "host_rule" {
+    for_each = var.okta_subdomain != null ? [1] : []
+    content {
+      hosts        = [var.okta_subdomain]
+      path_matcher = "okta"
+    }
+  }
+
+  dynamic "path_matcher" {
+    for_each = var.okta_subdomain != null ? [1] : []
+    content {
+      name            = "okta"
+      default_service = local.fleet_backend_self_link
+
+      path_rule {
+        paths = ["/api/fleet/conditional_access/idp/sso"]
+        url_redirect {
+          https_redirect = true
+          host_redirect  = var.okta_subdomain
+          path_redirect  = "/api/fleet/conditional_access/idp/sso"
+          strip_query    = false
+        }
+      }
+    }
+  }
 }
 
 # Configure the External HTTP(S) Load Balancer
@@ -21,7 +78,10 @@ module "fleet_lb" {
   ssl                             = true
   https_redirect                  = true
   managed_ssl_certificate_domains = [local.managed_ssl_domain]
-  server_tls_policy               = var.server_tls_policy
+
+  # Use our custom URL map so we can inject Okta redirect rules
+  create_url_map = false
+  url_map        = google_compute_url_map.fleet.self_link
 
   backends = {
     default = {
@@ -46,19 +106,88 @@ module "fleet_lb" {
     }
   }
 
-  depends_on = [google_compute_region_network_endpoint_group.neg]
+  depends_on = [
+    google_compute_region_network_endpoint_group.neg,
+  ]
 }
 
-# Create the DNS A Record for the Load Balancer
+# Create the DNS A Record for the main Fleet domain
 resource "google_dns_record_set" "fleet_dns_record" {
   project      = var.project_id
   managed_zone = google_dns_managed_zone.fleet_dns_zone.name
   name         = var.dns_record_name
   type         = "A"
-  ttl          = 300 # Time-to-live in seconds
+  ttl          = 300
 
-  # Point to the external IP address of the created load balancer
   rrdatas = [module.fleet_lb.external_ip]
 
   depends_on = [module.fleet_lb]
+}
+
+# ---------------------------------------------------------------------------
+# Okta mTLS subdomain — separate proxy, IP, cert, and forwarding rule so
+# that the mTLS ServerTLSPolicy only applies to okta.* traffic, not the
+# main Fleet UI. GCP attaches TLS policies at the proxy level, so a
+# dedicated proxy is required.
+# ---------------------------------------------------------------------------
+
+# Dedicated global IP for the Okta mTLS subdomain
+resource "google_compute_global_address" "okta" {
+  count   = var.okta_subdomain != null ? 1 : 0
+  project = var.project_id
+  name    = "${var.prefix}-okta-ip"
+}
+
+# Managed SSL cert for the Okta subdomain only
+resource "google_compute_managed_ssl_certificate" "okta" {
+  count   = var.okta_subdomain != null ? 1 : 0
+  project = var.project_id
+  name    = "${var.prefix}-okta-cert"
+
+  managed {
+    domains = [var.okta_subdomain]
+  }
+
+  lifecycle {
+    create_before_destroy = true
+  }
+}
+
+# HTTPS proxy with mTLS policy — only used for okta.* traffic
+resource "google_compute_target_https_proxy" "okta" {
+  count   = var.okta_subdomain != null ? 1 : 0
+  project = var.project_id
+  name    = "${var.prefix}-okta-https-proxy"
+
+  url_map          = google_compute_url_map.fleet.self_link
+  ssl_certificates = [google_compute_managed_ssl_certificate.okta[0].self_link]
+  server_tls_policy = var.server_tls_policy
+}
+
+# Forwarding rule: okta IP:443 → okta HTTPS proxy
+resource "google_compute_global_forwarding_rule" "okta_https" {
+  count   = var.okta_subdomain != null ? 1 : 0
+  project = var.project_id
+  name    = "${var.prefix}-okta-https"
+
+  ip_address = google_compute_global_address.okta[0].address
+  port_range = "443"
+  target     = google_compute_target_https_proxy.okta[0].self_link
+
+  depends_on = [google_compute_target_https_proxy.okta]
+}
+
+# DNS A record for the Okta mTLS subdomain — points to the dedicated okta IP
+resource "google_dns_record_set" "okta_dns_record" {
+  count = var.okta_subdomain != null ? 1 : 0
+
+  project      = var.project_id
+  managed_zone = google_dns_managed_zone.fleet_dns_zone.name
+  name         = "${var.okta_subdomain}."
+  type         = "A"
+  ttl          = 300
+
+  rrdatas = [google_compute_global_address.okta[0].address]
+
+  depends_on = [google_compute_global_address.okta]
 }

--- a/gcp/byo-project/loadbalancer.tf
+++ b/gcp/byo-project/loadbalancer.tf
@@ -16,19 +16,19 @@ module "fleet_lb" {
   version = "~> 12.0"
 
   project = var.project_id
-  name    = "${var.prefix}-lb" # e.g., fleet-lb
+  name    = "${var.prefix}-lb"
 
-  # SSL Configuration
   ssl                             = true
-  https_redirect                  = true # Enforce HTTPS
+  https_redirect                  = true
   managed_ssl_certificate_domains = [local.managed_ssl_domain]
+  server_tls_policy               = var.server_tls_policy
 
-  # Backend Configuration
   backends = {
     default = {
-      description = "Backend for Fleet Cloud Run service"
-      enable_cdn  = false # Set to true if you want Cloud CDN
-      protocol    = "HTTP"
+      description            = "Backend for Fleet Cloud Run service"
+      enable_cdn             = false
+      protocol               = "HTTP"
+      custom_request_headers = var.backend_custom_request_headers
       groups = [
         {
           group = google_compute_region_network_endpoint_group.neg.id
@@ -37,10 +37,9 @@ module "fleet_lb" {
 
       log_config = {
         enable      = true
-        sample_rate = 1.0 # Log all requests
+        sample_rate = 1.0
       }
 
-      # IAP (Identity-Aware Proxy) - disabled by default
       iap_config = {
         enable = false
       }

--- a/gcp/byo-project/loadbalancer.tf
+++ b/gcp/byo-project/loadbalancer.tf
@@ -28,18 +28,18 @@ resource "google_compute_url_map" "fleet" {
     create_before_destroy = true
   }
 
-  # Default host rule — sends all traffic to the Fleet backend
-  host_rule {
-    hosts        = ["*"]
-    path_matcher = "default"
-  }
-
-  path_matcher {
-    name            = "default"
-    default_service = local.fleet_backend_self_link
-  }
-
-  # Okta subdomain host rule — redirects SSO path, forwards everything else
+  # Okta subdomain host rule — forwards everything to the Fleet backend
+  # via the mTLS proxy (the proxy is what injects X-Client-Cert-Serial).
+  # No SSO redirect here: if the okta path_matcher carried a
+  # url_redirect to the okta subdomain, the LB would 301-loop
+  # okta.*/...idp/sso onto itself.
+  #
+  # Declaration order matters: GCP url_maps evaluate host_rules in
+  # declaration order (first match wins, NOT longest-prefix), so the
+  # specific okta host_rule must come before the `*` host_rule below.
+  # The Terraform google provider currently treats host_rule as an
+  # unordered set on read, so a manual gcloud reorder may be required
+  # the first time the rule is created (see README).
   dynamic "host_rule" {
     for_each = var.okta_subdomain != null ? [1] : []
     content {
@@ -53,8 +53,26 @@ resource "google_compute_url_map" "fleet" {
     content {
       name            = "okta"
       default_service = local.fleet_backend_self_link
+    }
+  }
 
-      path_rule {
+  # Default host rule — catches everything else (the main Fleet domain).
+  host_rule {
+    hosts        = ["*"]
+    path_matcher = "default"
+  }
+
+  path_matcher {
+    name            = "default"
+    default_service = local.fleet_backend_self_link
+
+    # Bounce Okta SSO callbacks from the main domain to the mTLS
+    # subdomain. Only fires on the main fleet domain because the okta
+    # host_rule above routes okta.* traffic to its own path_matcher
+    # (which has no redirect, so requests pass through to the backend).
+    dynamic "path_rule" {
+      for_each = var.okta_subdomain != null ? [1] : []
+      content {
         paths = ["/api/fleet/conditional_access/idp/sso"]
         url_redirect {
           https_redirect = true
@@ -63,6 +81,20 @@ resource "google_compute_url_map" "fleet" {
           strip_query    = false
         }
       }
+    }
+  }
+
+  # Okta CA SSO routing regression guard: requests to the okta
+  # subdomain must reach the Fleet backend (NOT self-redirect). An
+  # earlier shape placed the url_redirect path_rule inside the okta
+  # path_matcher, which 301-looped okta.*/...idp/sso onto itself.
+  dynamic "test" {
+    for_each = var.okta_subdomain != null ? [1] : []
+    content {
+      description = "okta SSO on the okta subdomain reaches the backend (no self-redirect)"
+      host        = var.okta_subdomain
+      path        = "/api/fleet/conditional_access/idp/sso"
+      service     = local.fleet_backend_self_link
     }
   }
 }

--- a/gcp/byo-project/variables.tf
+++ b/gcp/byo-project/variables.tf
@@ -100,6 +100,12 @@ variable "backend_custom_request_headers" {
   default     = []
 }
 
+variable "okta_subdomain" {
+  description = "Fully-qualified domain name for the Okta mTLS subdomain (e.g. 'okta.fleet.example.com'). When set, provisions a dedicated global IP, managed SSL cert, HTTPS proxy with the server_tls_policy attached, forwarding rule, DNS A record, and URL map redirect rule for the Okta SSO path."
+  type        = string
+  default     = null
+}
+
 variable "fleet_config" {
   type = object({
     installers_bucket_name = string

--- a/gcp/byo-project/variables.tf
+++ b/gcp/byo-project/variables.tf
@@ -88,6 +88,18 @@ variable "vpc_config" {
   }
 
 }
+variable "server_tls_policy" {
+  description = "Self-link of a ServerTLSPolicy to attach to the Fleet HTTPS proxy for mTLS. Set to the okta-conditional-access addon's server_tls_policy output to enable Okta conditional access."
+  type        = string
+  default     = null
+}
+
+variable "backend_custom_request_headers" {
+  description = "Custom request headers to add to the default Fleet backend service. Used to forward client cert info (e.g. X-Client-Cert-Serial) when mTLS is enabled."
+  type        = list(string)
+  default     = []
+}
+
 variable "fleet_config" {
   type = object({
     installers_bucket_name = string


### PR DESCRIPTION
## Summary

- Adds `addons/gcp/okta-conditional-access/` — a GCP-native equivalent of the existing AWS `okta-conditional-access` addon
- Updates `gcp/byo-project` with three new optional inputs: `server_tls_policy`, `backend_custom_request_headers`, and `okta_subdomain`

## Architecture

GCP's `ServerTLSPolicy` applies at the HTTPS proxy level — attaching it to the main proxy enforces mTLS on the Fleet UI too. To avoid that, this addon provisions a **dedicated second proxy and global IP** for `okta.<fleet_domain>`, leaving the main Fleet UI proxy untouched and mTLS-free.

```text
fleet.example.com      →  1.2.3.4  →  fleet-lb-https-proxy       (no mTLS)       →  Cloud Run
okta.fleet.example.com →  5.6.7.8  →  fleet-okta-https-proxy  (mTLS enforced)  →  Cloud Run
                                                 ↑
                                      ServerTLSPolicy (REJECT_INVALID)
                                      TrustConfig (Fleet SCEP CA)
```

Both proxies share the same URL map and backend service. The mTLS proxy forwards the client cert serial to Fleet via `X-Client-Cert-Serial`.

When `okta_subdomain` is set, `gcp/byo-project` automatically:
1. Provisions a dedicated global IP (`fleet-okta-ip`)
2. Creates a managed SSL cert for `okta.<fleet_domain>` only
3. Creates a second HTTPS proxy with the `ServerTLSPolicy` attached
4. Creates a forwarding rule on the new IP → okta proxy
5. Adds a URL map host rule redirecting `/api/fleet/conditional_access/idp/sso` to the okta subdomain
6. Creates a DNS A record for `okta.<fleet_domain>` pointing to the new IP

## Differences from AWS Addon

| Concern | AWS | GCP |
| --- | --- | --- |
| CA cert storage | S3 bucket | Inline in `TrustConfig` (no object storage needed) |
| mTLS termination | Separate ALB | Dedicated proxy on existing LB |
| Cert revocation | Supported | Not supported by GCP LB (Fleet still enforces it) |
| Serial header | ALB-native | Custom request header `{client_cert_serial_number}` |
| Extra infrastructure cost | Second ALB + global IP | Second global IP only |

## Disclosure

This module was written with Claude (Anthropic) as a coding assistant. I reviewed the implementation, tested it end-to-end, and have been running it in production at [CampusGroup](https://campus.edu) with Okta conditional access enabled on our Fleet deployment since April 2026.

## Test plan

- [ ] `terraform validate` passes
- [ ] Deploy addon against an existing `gcp/byo-project` Fleet stack
- [ ] Confirm main Fleet UI is accessible without a client cert prompt
- [ ] Confirm `fleet-okta-https-proxy` has `ServerTLSPolicy` attached
- [ ] Confirm `X-Client-Cert-Serial` header is forwarded to Fleet on mTLS connections on the okta subdomain
- [ ] Confirm non-mTLS connections are rejected at the LB for the `okta.*` subdomain
- [ ] Confirm Okta SSO redirect path (`/api/fleet/conditional_access/idp/sso`) routes correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code), reviewed and deployed by @robbiet480