### PR TITLE
Support Windows MDM secrets for GCP

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,6 @@
 
 .terraform
 terraform.tfstate*
+terraform.tfvars
+*.key
+*.crt

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+.DS_Store
 .external_modules
 .idea
 

--- a/gcp/byo-project/iam.tf
+++ b/gcp/byo-project/iam.tf
@@ -30,21 +30,17 @@ resource "google_project_iam_member" "fleet_run_sa_monitoring_writer" {
 }
 
 
-resource "google_secret_manager_secret_iam_member" "fleet_run_sa_db_secret_access" {
+resource "google_secret_manager_secret_iam_member" "fleet_run_sa_secret_access" {
+  for_each = local.fleet_secrets_env_vars
+
   project   = var.project_id
-  secret_id = google_secret_manager_secret.database_password.id
+  secret_id = each.value.secret
   role      = "roles/secretmanager.secretAccessor"
   member    = "serviceAccount:${google_service_account.fleet_run_sa.email}"
 
-  depends_on = [google_secret_manager_secret.database_password]
-}
-
-resource "google_secret_manager_secret_iam_member" "fleet_run_sa_private_key_secret_access" {
-  project   = var.project_id
-  secret_id = google_secret_manager_secret.private_key.id
-  role      = "roles/secretmanager.secretAccessor"
-  member    = "serviceAccount:${google_service_account.fleet_run_sa.email}"
-
-  depends_on = [google_secret_manager_secret.private_key]
+  depends_on = [
+    google_secret_manager_secret.database_password,
+    google_secret_manager_secret.private_key,
+  ]
 }
 

--- a/gcp/main.tf
+++ b/gcp/main.tf
@@ -43,10 +43,58 @@ module "project_factory" {
     "monitoring.googleapis.com",
     "memorystore.googleapis.com",
     "serviceconsumermanagement.googleapis.com",
-    "networkconnectivity.googleapis.com"
+    "networkconnectivity.googleapis.com",
+    "networksecurity.googleapis.com",
+    "certificatemanager.googleapis.com"
   ]
 
   labels = var.labels
+}
+
+resource "google_secret_manager_secret" "mdm_wstep_cert" {
+  project   = module.project_factory.project_id
+  secret_id = "fleet-mdm-wstep-identity-cert"
+  replication {
+    auto {}
+  }
+}
+
+resource "google_secret_manager_secret_version" "mdm_wstep_cert" {
+  secret      = google_secret_manager_secret.mdm_wstep_cert.name
+  secret_data = var.windows_mdm_wstep_identity_cert
+}
+
+resource "google_secret_manager_secret" "mdm_wstep_key" {
+  project   = module.project_factory.project_id
+  secret_id = "fleet-mdm-wstep-identity-key"
+  replication {
+    auto {}
+  }
+}
+
+resource "google_secret_manager_secret_version" "mdm_wstep_key" {
+  secret      = google_secret_manager_secret.mdm_wstep_key.name
+  secret_data = var.windows_mdm_wstep_identity_key
+}
+
+locals {
+  windows_mdm_secret_env_vars = {
+    FLEET_MDM_WINDOWS_WSTEP_IDENTITY_CERT_BYTES = {
+      secret  = google_secret_manager_secret.mdm_wstep_cert.secret_id
+      version = "latest"
+    }
+    FLEET_MDM_WINDOWS_WSTEP_IDENTITY_KEY_BYTES = {
+      secret  = google_secret_manager_secret.mdm_wstep_key.secret_id
+      version = "latest"
+    }
+  }
+}
+
+module "okta_conditional_access" {
+  source                  = "../addons/gcp/okta-conditional-access"
+  project_id              = module.project_factory.project_id
+  ca_certificate_pem_file = "${path.module}/resources/conditional-ca.pem"
+  fleet_domain            = "fleet.campusgroup.co"
 }
 
 module "fleet" {
@@ -55,9 +103,18 @@ module "fleet" {
   dns_record_name = var.dns_record_name
   dns_zone_name   = var.dns_zone_name
   vpc_config      = var.vpc_config
-  fleet_config    = var.fleet_config
+  fleet_config    = merge(var.fleet_config, {
+    extra_secret_env_vars = merge(
+      coalesce(var.fleet_config.extra_secret_env_vars, {}),
+      local.windows_mdm_secret_env_vars,
+    )
+  })
   cache_config    = var.cache_config
   database_config = var.database_config
   region          = var.region
   location        = var.location
+
+  server_tls_policy              = module.okta_conditional_access.server_tls_policy
+  backend_custom_request_headers = [module.okta_conditional_access.client_cert_header]
+  okta_subdomain                 = "okta.fleet.campusgroup.co"
 }

--- a/gcp/main.tf
+++ b/gcp/main.tf
@@ -43,9 +43,7 @@ module "project_factory" {
     "monitoring.googleapis.com",
     "memorystore.googleapis.com",
     "serviceconsumermanagement.googleapis.com",
-    "networkconnectivity.googleapis.com",
-    "networksecurity.googleapis.com",
-    "certificatemanager.googleapis.com"
+    "networkconnectivity.googleapis.com"
   ]
 
   labels = var.labels
@@ -60,9 +58,9 @@ resource "google_secret_manager_secret" "mdm_wstep_cert" {
 }
 
 resource "google_secret_manager_secret_version" "mdm_wstep_cert" {
-  secret           = google_secret_manager_secret.mdm_wstep_cert.name
-  secret_data_wo   = var.windows_mdm_wstep_identity_cert
-  secret_data_wo_version = 1
+  secret                 = google_secret_manager_secret.mdm_wstep_cert.name
+  secret_data_wo         = var.windows_mdm_wstep_identity_cert
+  secret_data_wo_version = 2
 }
 
 resource "google_secret_manager_secret" "mdm_wstep_key" {
@@ -76,7 +74,7 @@ resource "google_secret_manager_secret" "mdm_wstep_key" {
 resource "google_secret_manager_secret_version" "mdm_wstep_key" {
   secret                 = google_secret_manager_secret.mdm_wstep_key.name
   secret_data_wo         = var.windows_mdm_wstep_identity_key
-  secret_data_wo_version = 1
+  secret_data_wo_version = 2
 }
 
 locals {
@@ -90,13 +88,6 @@ locals {
       version = "latest"
     }
   }
-}
-
-module "okta_conditional_access" {
-  source                  = "../addons/gcp/okta-conditional-access"
-  project_id              = module.project_factory.project_id
-  ca_certificate_pem_file = "${path.module}/resources/conditional-ca.pem"
-  fleet_domain            = "fleet.campusgroup.co"
 }
 
 module "fleet" {
@@ -115,8 +106,4 @@ module "fleet" {
   database_config = var.database_config
   region          = var.region
   location        = var.location
-
-  server_tls_policy              = module.okta_conditional_access.server_tls_policy
-  backend_custom_request_headers = [module.okta_conditional_access.client_cert_header]
-  okta_subdomain                 = "okta.fleet.campusgroup.co"
 }

--- a/gcp/main.tf
+++ b/gcp/main.tf
@@ -60,8 +60,9 @@ resource "google_secret_manager_secret" "mdm_wstep_cert" {
 }
 
 resource "google_secret_manager_secret_version" "mdm_wstep_cert" {
-  secret      = google_secret_manager_secret.mdm_wstep_cert.name
-  secret_data = var.windows_mdm_wstep_identity_cert
+  secret           = google_secret_manager_secret.mdm_wstep_cert.name
+  secret_data_wo   = var.windows_mdm_wstep_identity_cert
+  secret_data_wo_version = 1
 }
 
 resource "google_secret_manager_secret" "mdm_wstep_key" {
@@ -73,8 +74,9 @@ resource "google_secret_manager_secret" "mdm_wstep_key" {
 }
 
 resource "google_secret_manager_secret_version" "mdm_wstep_key" {
-  secret      = google_secret_manager_secret.mdm_wstep_key.name
-  secret_data = var.windows_mdm_wstep_identity_key
+  secret                 = google_secret_manager_secret.mdm_wstep_key.name
+  secret_data_wo         = var.windows_mdm_wstep_identity_key
+  secret_data_wo_version = 1
 }
 
 locals {

--- a/gcp/variables.tf
+++ b/gcp/variables.tf
@@ -2,6 +2,18 @@ variable "project_name" {
   default = "fleet"
 }
 
+variable "windows_mdm_wstep_identity_cert" {
+  description = "PEM-encoded certificate for Windows MDM WSTEP identity (FLEET_MDM_WINDOWS_WSTEP_IDENTITY_CERT_BYTES)"
+  type        = string
+  sensitive   = true
+}
+
+variable "windows_mdm_wstep_identity_key" {
+  description = "PEM-encoded private key for Windows MDM WSTEP identity (FLEET_MDM_WINDOWS_WSTEP_IDENTITY_KEY_BYTES)"
+  type        = string
+  sensitive   = true
+}
+
 variable "org_id" {
   description = "organization id"
 }


### PR DESCRIPTION
## Summary

This PR adds GCP Secret Manager support for the [Windows MDM WSTEP identity certificate and key](https://fleetdm.com/guides/windows-mdm-setup#basic-article), enabling the GCP Terraform module to provision and expose these secrets to Fleet via Cloud Run's secret environment variable injection.

### Changes

**`gcp/main.tf`**
- Creates two GCP Secret Manager secrets: `fleet-mdm-wstep-identity-cert` and `fleet-mdm-wstep-identity-key`
- Uses `secret_data_wo` (write-only) for secret versions to avoid storing sensitive values in Terraform state
- Injects the secrets into Fleet's Cloud Run service as `FLEET_MDM_WINDOWS_WSTEP_IDENTITY_CERT_BYTES` and `FLEET_MDM_WINDOWS_WSTEP_IDENTITY_KEY_BYTES` via `extra_secret_env_vars`

**`gcp/variables.tf`**
- Adds `windows_mdm_wstep_identity_cert` and `windows_mdm_wstep_identity_key` input variables (sensitive strings, PEM-encoded)

**`gcp/byo-project/iam.tf`**
- Consolidates the two separate `google_secret_manager_secret_iam_member` resources into a single `for_each`-based resource that iterates over all secrets in `local.fleet_secrets_env_vars` — this ensures the Fleet Cloud Run service account automatically gets Secret Accessor access to any secrets added via `extra_secret_env_vars`, including the new WSTEP secrets

**`.gitignore`**
- Adds `.DS_Store`, `terraform.tfvars`, `*.key`, and `*.crt` to prevent accidental commits of local state and key material

### Usage

Provide the WSTEP cert and key via `terraform.tfvars` or a secrets manager pipeline:

```hcl
windows_mdm_wstep_identity_cert = <<-EOT
  -----BEGIN CERTIFICATE-----
  ...
  -----END CERTIFICATE-----
EOT

windows_mdm_wstep_identity_key = <<-EOT
  -----BEGIN PRIVATE KEY-----
  ...
  -----END PRIVATE KEY-----
EOT
``` 

These map directly to the `FLEET_MDM_WINDOWS_WSTEP_IDENTITY_CERT_BYTES` and `FLEET_MDM_WINDOWS_WSTEP_IDENTITY_KEY_BYTES` environment variables required by Fleet for Windows MDM enrollment.

---

*PR description drafted with Claude (claude.ai/claude-code), reviewed by author.*
