### PR TITLE
Add GCP service account and secret for Fleet Google Calendar integration

### DIFF
--- a/gcp/main.tf
+++ b/gcp/main.tf
@@ -49,6 +49,40 @@ module "project_factory" {
   labels = var.labels
 }
 
+# -------------------------------------
+# Google Calendar Integration
+# -------------------------------------
+
+resource "google_service_account" "fleet_calendar" {
+  project      = module.project_factory.project_id
+  account_id   = "fleet-calendar-events"
+  display_name = "Fleet Calendar Events"
+  description  = "Service account for Fleet to create calendar events for end users with failing policies"
+}
+
+resource "google_service_account_key" "fleet_calendar" {
+  service_account_id = google_service_account.fleet_calendar.name
+}
+
+resource "google_secret_manager_secret" "fleet_calendar_key" {
+  project   = module.project_factory.project_id
+  secret_id = "fleet-calendar-service-account-key"
+  replication {
+    auto {}
+  }
+}
+
+resource "google_secret_manager_secret_version" "fleet_calendar_key" {
+  secret      = google_secret_manager_secret.fleet_calendar_key.name
+  secret_data = base64decode(google_service_account_key.fleet_calendar.private_key)
+}
+
+output "fleet_calendar_service_account_key_json" {
+  description = "Google Calendar service account key JSON — set this as FLEET_GOOGLE_CALENDAR_SERVICE_ACCOUNT_KEY in GitHub Actions secrets"
+  value       = base64decode(google_service_account_key.fleet_calendar.private_key)
+  sensitive   = true
+}
+
 module "fleet" {
   source          = "./byo-project"
   project_id      = module.project_factory.project_id


### PR DESCRIPTION
## Summary

This PR adds the GCP infrastructure needed to support Fleet's [Google Calendar integration](https://fleetdm.com/docs/using-fleet/calendar-events) for policy-based calendar events.

### Changes

**`gcp/main.tf`**
- Creates a dedicated GCP service account (`fleet-calendar-events`) scoped to the Fleet project
- Generates a service account key and stores it in Secret Manager as `fleet-calendar-service-account-key`
- Adds a sensitive output (`fleet_calendar_service_account_key_json`) containing the key JSON, intended to be captured once and stored as `FLEET_GOOGLE_CALENDAR_SERVICE_ACCOUNT_KEY` in your CI/CD secrets or Fleet server configuration

### Usage

After applying, retrieve the key from the Terraform output and configure it in Fleet:

```shell
terraform output -raw fleet_calendar_service_account_key_json
```

Set the result as the `FLEET_GOOGLE_CALENDAR_SERVICE_ACCOUNT_KEY` environment variable on your Fleet server (or store it in Secret Manager and inject it via Cloud Run secret env vars).

You will also need to complete the Google Workspace side of the setup (domain-wide delegation for the service account) per the [Fleet calendar events documentation](https://fleetdm.com/docs/using-fleet/calendar-events).

---

*PR description drafted with Claude (claude.ai/claude-code), reviewed by author.*