### PR TITLE
Bump Fleet version references to v4.85.0

### DIFF
--- a/byo-vpc/byo-db/byo-ecs/variables.tf
+++ b/byo-vpc/byo-db/byo-ecs/variables.tf
@@ -41,7 +41,7 @@ variable "fleet_config" {
     pid_mode                     = optional(string, null)
     command                      = optional(list(string), null)
     private_key_delivery_method  = optional(string, "ecs")
-    image                        = optional(string, "fleetdm/fleet:v4.84.3")
+    image                        = optional(string, "fleetdm/fleet:v4.85.0")
     family                       = optional(string, "fleet")
     sidecars                     = optional(list(any), [])
     depends_on                   = optional(list(any), [])
@@ -203,7 +203,7 @@ variable "fleet_config" {
     pid_mode                     = null
     command                      = null
     private_key_delivery_method  = "ecs"
-    image                        = "fleetdm/fleet:v4.84.3"
+    image                        = "fleetdm/fleet:v4.85.0"
     family                       = "fleet"
     sidecars                     = []
     depends_on                   = []

--- a/byo-vpc/byo-db/variables.tf
+++ b/byo-vpc/byo-db/variables.tf
@@ -162,7 +162,7 @@ variable "fleet_config" {
     pid_mode                     = optional(string, null)
     command                      = optional(list(string), null)
     private_key_delivery_method  = optional(string, "ecs")
-    image                        = optional(string, "fleetdm/fleet:v4.84.3")
+    image                        = optional(string, "fleetdm/fleet:v4.85.0")
     family                       = optional(string, "fleet")
     sidecars                     = optional(list(any), [])
     depends_on                   = optional(list(any), [])
@@ -364,7 +364,7 @@ variable "fleet_config" {
     pid_mode                     = null
     command                      = null
     private_key_delivery_method  = "ecs"
-    image                        = "fleetdm/fleet:v4.84.3"
+    image                        = "fleetdm/fleet:v4.85.0"
     family                       = "fleet"
     sidecars                     = []
     depends_on                   = []

--- a/byo-vpc/example/main.tf
+++ b/byo-vpc/example/main.tf
@@ -17,7 +17,7 @@ provider "aws" {
 }
 
 locals {
-  fleet_image = "fleetdm/fleet:v4.84.3"
+  fleet_image = "fleetdm/fleet:v4.85.0"
   domain_name = "example.com"
 }
 

--- a/byo-vpc/variables.tf
+++ b/byo-vpc/variables.tf
@@ -431,7 +431,7 @@ variable "fleet_config" {
     pid_mode                     = optional(string, null)
     command                      = optional(list(string), null)
     private_key_delivery_method  = optional(string, "ecs")
-    image                        = optional(string, "fleetdm/fleet:v4.84.3")
+    image                        = optional(string, "fleetdm/fleet:v4.85.0")
     family                       = optional(string, "fleet")
     sidecars                     = optional(list(any), [])
     depends_on                   = optional(list(any), [])
@@ -633,7 +633,7 @@ variable "fleet_config" {
     pid_mode                     = null
     command                      = null
     private_key_delivery_method  = "ecs"
-    image                        = "fleetdm/fleet:v4.84.3"
+    image                        = "fleetdm/fleet:v4.85.0"
     family                       = "fleet"
     sidecars                     = []
     depends_on                   = []

--- a/example/main.tf
+++ b/example/main.tf
@@ -89,7 +89,7 @@ module "fleet" {
   fleet_config = {
     # To avoid pull-rate limiting from dockerhub, consider using our quay.io mirror
     # for the Fleet image. e.g. "quay.io/fleetdm/fleet:v4.67.0"
-    image = "fleetdm/fleet:v4.84.3" # override default to deploy the image you desire
+    image = "fleetdm/fleet:v4.85.0" # override default to deploy the image you desire
     # See https://fleetdm.com/docs/deploy/reference-architectures#aws for appropriate scaling
     # memory and cpu.
     autoscaling = {

--- a/gcp/.header.md
+++ b/gcp/.header.md
@@ -89,7 +89,7 @@ This Terraform project automates the deployment of Fleet Device Management (Flee
 *   `dns_zone_name`: The DNS zone that will be created/managed in Cloud DNS (e.g., `mydomain.com.`). **Must end with a dot.**
 *   `dns_record_name`: The specific DNS record for Fleet (e.g., `fleet.mydomain.com.`). **Must end with a dot.**
 *   `project_name`: A descriptive name for the project to be created.
-*   `fleet_config.image_tag`: The Docker image tag for the Fleet version you want to deploy (e.g., `fleetdm/fleet:v4.84.3`).
+*   `fleet_config.image_tag`: The Docker image tag for the Fleet version you want to deploy (e.g., `fleetdm/fleet:v4.85.0`).
 *   `fleet_config.exec_migration`: Set to `true` when you are upgrading the `fleet_config.image_tag` to automatically run database migrations. Set to `false` if you want to manage migrations manually or if it's not an image upgrade.
 *   `fleet_config.license_key` (Optional, inside the `fleet_config` object): Your Fleet license key if you have one.
 

--- a/gcp/byo-project/variables.tf
+++ b/gcp/byo-project/variables.tf
@@ -107,7 +107,7 @@ variable "fleet_config" {
     })))
   })
   default = {
-    image_tag              = "fleetdm/fleet:v4.84.3"
+    image_tag              = "fleetdm/fleet:v4.85.0"
     installers_bucket_name = ""
     fleet_cpu              = "1000m"
     fleet_memory           = "4096Mi"

--- a/gcp/variables.tf
+++ b/gcp/variables.tf
@@ -137,7 +137,7 @@ variable "fleet_config" {
     })))
   })
   default = {
-    image_tag              = "fleetdm/fleet:v4.84.3"
+    image_tag              = "fleetdm/fleet:v4.85.0"
     installers_bucket_name = "" # Bucket names must be globally unique
     fleet_cpu              = "1000m"
     fleet_memory           = "4096Mi"

--- a/variables.tf
+++ b/variables.tf
@@ -519,7 +519,7 @@ variable "fleet_config" {
     pid_mode                     = optional(string, null)
     command                      = optional(list(string), null)
     private_key_delivery_method  = optional(string, "ecs")
-    image                        = optional(string, "fleetdm/fleet:v4.84.3")
+    image                        = optional(string, "fleetdm/fleet:v4.85.0")
     family                       = optional(string, "fleet")
     sidecars                     = optional(list(any), [])
     depends_on                   = optional(list(any), [])
@@ -721,7 +721,7 @@ variable "fleet_config" {
     pid_mode                     = null
     command                      = null
     private_key_delivery_method  = "ecs"
-    image                        = "fleetdm/fleet:v4.84.3"
+    image                        = "fleetdm/fleet:v4.85.0"
     family                       = "fleet"
     sidecars                     = []
     depends_on                   = []


### PR DESCRIPTION
Release step 6: bump Fleet image references from v4.84.3 to v4.85.0.

## Changes

Updated 13 occurrences of \`fleetdm/fleet:v4.84.3\` → \`fleetdm/fleet:v4.85.0\` across 9 .tf and .md files:

- \`variables.tf\` (2)
- \`byo-vpc/variables.tf\` (2)
- \`byo-vpc/byo-db/variables.tf\` (2)
- \`byo-vpc/byo-db/byo-ecs/variables.tf\` (2)
- \`byo-vpc/example/main.tf\` (1)
- \`example/main.tf\` (1)
- \`gcp/variables.tf\` (1)
- \`gcp/byo-project/variables.tf\` (1)
- \`gcp/.header.md\` (1)

## Out of scope (worth a separate cleanup pass)

The auto-generated \`README.md\` files in several modules still reference older versions (e.g. v4.83.0 in the root README.md and byo-vpc READMEs, v4.80.0 / v4.78.2 in gcp/README.md). These are stale terraform-docs output, not source of truth. A separate \`terraform-docs\` regeneration sweep would clear them up — not bundling here to keep the release bump focused.

Also untouched: example placeholders in addon \`.header.md\` files (\`v4.70.1\`) and the comment in \`example/main.tf:91\` (\`v4.67.0\`).