### PR TITLE
[codex] Add h2c bulk backend for GCP installer transfers

### DIFF
--- a/gcp/README.md
+++ b/gcp/README.md
@@ -95,14 +95,9 @@ Review `variables.tf` and `byo-project/variables.tf` for all available options a
 
 ## Known Limitations
 
-1. To handle large uploads, we need to bypass GCP cloud run's 32MB HTTP/1 body limit, by setting `fleet_config.use_h2c = true` which forces Fleet to use HTTP/2. However, as Cloud Run documentation notes, HTTP/2 end-to-end breaks connection upgrades, affecting WebSocket support and Fleet functionality for features such as Live Queries.
-    
-    **Workaround**: [Use Fleet Gitops Flow](https://fleetdm.com/docs/using-fleet/gitops#managing-software-installers)
-    * Set `fleet_config.use_h2c = false` to force HTTP/1
-    * If you have large uploads, use `fleetctl apply` with a url field in your software YAML. The data flow avoids the ingress limit:
-        * Apply the YAML (small request).
-        * The Fleet Server makes an outbound GET request to download the file from the URL (S3, GCS, etc).
-        * Cloud Run doesn't apply the 32MB limit to outbound requests.
+1. To handle large software installer uploads and downloads without breaking WebSocket-dependent Fleet features, this module keeps the primary Fleet Cloud Run service on HTTP/1 by default and creates a second h2c Cloud Run service for byte-heavy software installer paths. The load balancer routes software package upload/download endpoints to the h2c service while normal Fleet UI/API/WebSocket traffic stays on the primary service.
+
+    Keep `fleet_config.use_h2c = false` unless you intentionally want all Fleet traffic to use h2c. The per-path h2c service is the preferred workaround for Cloud Run's 32MB HTTP/1 request and non-streaming response limits.
 
 ## Deployment Steps
 

--- a/gcp/byo-project/cloud_run.tf
+++ b/gcp/byo-project/cloud_run.tf
@@ -36,6 +36,9 @@ locals {
     FLEET_S3_SOFTWARE_INSTALLERS_FORCE_S3_PATH_STYLE = "true"
     FLEET_S3_SOFTWARE_INSTALLERS_REGION              = var.region
   })
+  fleet_bulk_env_vars = merge(local.fleet_env_vars, {
+    FLEET_SERVER_FORCE_H2C = "true"
+  })
 
   fleet_vpc_network_id = module.vpc.network_id
   # Use the direct construction for the subnet ID key as discussed
@@ -113,6 +116,77 @@ module "fleet-service" {
       }
 
       env_vars        = local.fleet_env_vars
+      env_secret_vars = local.fleet_secrets_env_vars
+    }
+  ]
+}
+
+module "fleet-bulk-service" {
+  source  = "GoogleCloudPlatform/cloud-run/google//modules/v2"
+  version = "0.17.2"
+
+  service_name                  = "fleet-api-bulk"
+  project_id                    = var.project_id
+  location                      = var.region
+  create_service_account        = false
+  service_account               = google_service_account.fleet_run_sa.email
+  enable_prometheus_sidecar     = false
+  cloud_run_deletion_protection = false
+
+  vpc_access = {
+    network_interfaces = {
+      network    = local.fleet_vpc_network_id
+      subnetwork = local.fleet_vpc_subnet_id
+    }
+    egress = "ALL_TRAFFIC"
+  }
+  ingress = "INGRESS_TRAFFIC_INTERNAL_LOAD_BALANCER"
+  timeout = "300s"
+
+  service_scaling = {
+    min_instance_count = 0
+  }
+
+  template_scaling = {
+    min_instance_count = 0
+    max_instance_count = var.fleet_config.max_instance_count
+  }
+
+  containers = [
+    {
+      container_image = local.fleet_image_tag
+      ports = {
+        name           = "h2c"
+        container_port = 8080
+      }
+
+      startup_probe = {
+        initial_delay_seconds = 30
+        timeout_seconds       = 2
+        period_seconds        = 60
+        failure_threshold     = 3
+
+        tcp_socket = {
+          port = 8080
+        }
+      }
+
+      liveness_probe = {
+        initial_delay_seconds = 30
+        timeout_seconds       = 2
+        failure_threshold     = 3
+        period_seconds        = 60
+        http_get = {
+          path         = "/healthz"
+          http_headers = []
+        }
+      }
+
+      resources = {
+        limits = local.fleet_resources_limits
+      }
+
+      env_vars        = local.fleet_bulk_env_vars
       env_secret_vars = local.fleet_secrets_env_vars
     }
   ]
@@ -214,6 +288,17 @@ resource "google_compute_region_network_endpoint_group" "neg" {
   depends_on = [module.fleet-service]
 }
 
+resource "google_compute_region_network_endpoint_group" "bulk_neg" {
+  name                  = "${var.prefix}-bulk-neg"
+  region                = var.region
+  project               = var.project_id
+  network_endpoint_type = "SERVERLESS"
+  cloud_run {
+    service = module.fleet-bulk-service.service_name
+  }
+  depends_on = [module.fleet-bulk-service]
+}
+
 data "google_project" "project" {
   project_id = var.project_id
 }
@@ -222,6 +307,14 @@ resource "google_cloud_run_v2_service_iam_member" "allow_lb_invoker" {
   project  = var.project_id
   location = module.fleet-service.location
   name     = module.fleet-service.service_name
+  role     = "roles/run.invoker"
+  member   = "allUsers"
+}
+
+resource "google_cloud_run_v2_service_iam_member" "allow_lb_bulk_invoker" {
+  project  = var.project_id
+  location = module.fleet-bulk-service.location
+  name     = module.fleet-bulk-service.service_name
   role     = "roles/run.invoker"
   member   = "allUsers"
 }

--- a/gcp/byo-project/loadbalancer.tf
+++ b/gcp/byo-project/loadbalancer.tf
@@ -1,6 +1,22 @@
 locals {
   # Clean the DNS record name for use in managed SSL cert domains (remove trailing dot)
   managed_ssl_domain = trim(var.dns_record_name, ".")
+
+  # The lb-http module names backend services "${name}-backend-${key}".
+  # These direct self_links avoid a url_map <-> module dependency cycle when
+  # the module is configured to use this custom URL map.
+  fleet_backend_self_link      = "https://www.googleapis.com/compute/v1/projects/${var.project_id}/global/backendServices/${var.prefix}-lb-backend-default"
+  fleet_bulk_backend_self_link = "https://www.googleapis.com/compute/v1/projects/${var.project_id}/global/backendServices/${var.prefix}-lb-backend-bulk"
+
+  fleet_bulk_paths = [
+    "/api/fleet/orbit/software_install/package",
+    "/api/latest/fleet/software/*",
+    "/api/v1/fleet/software/*",
+    "/api/latest/fleet/mdm/apple/installers",
+    "/api/latest/fleet/mdm/apple/installers/*",
+    "/api/v1/fleet/mdm/apple/installers",
+    "/api/v1/fleet/mdm/apple/installers/*",
+  ]
 }
 
 # Create/Manage the DNS Zone in Cloud DNS
@@ -8,6 +24,31 @@ resource "google_dns_managed_zone" "fleet_dns_zone" {
   project  = var.project_id
   name     = "${var.prefix}-zone"
   dns_name = var.dns_zone_name
+}
+
+resource "google_compute_url_map" "fleet" {
+  project         = var.project_id
+  name            = "${var.prefix}-lb-routing"
+  default_service = local.fleet_backend_self_link
+
+  lifecycle {
+    create_before_destroy = true
+  }
+
+  host_rule {
+    hosts        = ["*"]
+    path_matcher = "default"
+  }
+
+  path_matcher {
+    name            = "default"
+    default_service = local.fleet_backend_self_link
+
+    path_rule {
+      paths   = local.fleet_bulk_paths
+      service = local.fleet_bulk_backend_self_link
+    }
+  }
 }
 
 # Configure the External HTTP(S) Load Balancer
@@ -22,6 +63,8 @@ module "fleet_lb" {
   ssl                             = true
   https_redirect                  = true # Enforce HTTPS
   managed_ssl_certificate_domains = [local.managed_ssl_domain]
+  create_url_map                  = false
+  url_map                         = google_compute_url_map.fleet.self_link
 
   # Backend Configuration
   backends = {
@@ -45,9 +88,33 @@ module "fleet_lb" {
         enable = false
       }
     }
+
+    bulk = {
+      description = "h2c backend for large Fleet software installer transfers"
+      enable_cdn  = false
+      protocol    = "HTTP"
+      groups = [
+        {
+          group = google_compute_region_network_endpoint_group.bulk_neg.id
+        }
+      ]
+
+      log_config = {
+        enable      = true
+        sample_rate = 1.0 # Log all requests
+      }
+
+      # IAP (Identity-Aware Proxy) - disabled by default
+      iap_config = {
+        enable = false
+      }
+    }
   }
 
-  depends_on = [google_compute_region_network_endpoint_group.neg]
+  depends_on = [
+    google_compute_region_network_endpoint_group.neg,
+    google_compute_region_network_endpoint_group.bulk_neg,
+  ]
 }
 
 # Create the DNS A Record for the Load Balancer


### PR DESCRIPTION
## Summary

Cloud Run's HTTP/1 request body and non-streaming response limits make large Fleet software installer upload/download paths fail unless the whole Fleet service is forced to h2c. That global workaround breaks connection upgrades, which affects WebSocket-dependent Fleet features.

This adds a second Cloud Run service for large software installer transfer paths and forces only that service to h2c. The primary Fleet service remains on the existing `fleet_config.use_h2c` setting, so normal UI/API/WebSocket traffic can stay on HTTP/1 while byte-heavy package paths route through the h2c backend.

## Changes

- Add a `fleet-api-bulk` Cloud Run service using the same image, service account, VPC, resources, and secrets as the primary Fleet service, with `FLEET_SERVER_FORCE_H2C=true` and an h2c container port.
- Add a serverless NEG and load balancer backend for the bulk service.
- Manage a custom URL map so Fleet software installer upload/download paths route to the bulk backend while all other paths use the default backend.
- Update the GCP README limitation/workaround text to document the per-path h2c behavior.

## Validation

- `terraform fmt gcp/byo-project/cloud_run.tf gcp/byo-project/loadbalancer.tf`
- `terraform -chdir=gcp validate`
