### PR TITLE
k8s: fix MySQL-TLS schema references in deploy/job/cronjob

### DIFF
--- a/k8s/cronjob.tf
+++ b/k8s/cronjob.tf
@@ -107,7 +107,7 @@ resource "kubernetes_cron_job_v1" "fleet_vuln_processing_cron_job" {
               dynamic "env" {
                 for_each = local.database.tls.enabled ? [
                   { name = "FLEET_MYSQL_TLS_CA", value = "/secrets/mysql/${local.database.tls.ca_cert_key}" },
-                  { name = "FLEET_MYSQL_TLS_CERT", value = "/secrets/mysql/${local.database.tls.cert_secret_key}" },
+                  { name = "FLEET_MYSQL_TLS_CERT", value = "/secrets/mysql/${local.database.tls.cert_key}" },
                   { name = "FLEET_MYSQL_TLS_KEY", value = "/secrets/mysql/${local.database.tls.key_key}" },
                   { name = "FLEET_MYSQL_TLS_CONFIG", value = local.database.tls.config },
                   { name = "FLEET_MYSQL_TLS_SERVER_NAME", value = local.database.tls.server_name }
@@ -348,7 +348,7 @@ resource "kubernetes_cron_job_v1" "fleet_vuln_processing_cron_job" {
               for_each = local.database.tls.enabled ? [
                 {
                   name        = "mysql-tls",
-                  secret_name = local.database.tls.secret_name
+                  secret_name = local.database.secret_name
                 }
               ] : []
 

--- a/k8s/deploy.tf
+++ b/k8s/deploy.tf
@@ -259,7 +259,7 @@ resource "kubernetes_deployment" "fleet" {
           dynamic "env" {
             for_each = local.database.tls.enabled ? [
               { name = "FLEET_MYSQL_TLS_CA", value = "/secrets/mysql/${local.database.tls.ca_cert_key}" },
-              { name = "FLEET_MYSQL_TLS_CERT", value = "/secrets/mysql/${local.database.tls.cert_secret_key}" },
+              { name = "FLEET_MYSQL_TLS_CERT", value = "/secrets/mysql/${local.database.tls.cert_key}" },
               { name = "FLEET_MYSQL_TLS_KEY", value = "/secrets/mysql/${local.database.tls.key_key}" },
               { name = "FLEET_MYSQL_TLS_CONFIG", value = local.database.tls.config },
               { name = "FLEET_MYSQL_TLS_SERVER_NAME", value = local.database.tls.server_name }
@@ -893,7 +893,7 @@ resource "kubernetes_deployment" "fleet" {
           for_each = local.database.tls.enabled ? [
             {
               name        = "mysql-tls",
-              secret_name = local.database.tls.secret_name
+              secret_name = local.database.secret_name
             }
           ] : []
 

--- a/k8s/job.tf
+++ b/k8s/job.tf
@@ -103,7 +103,7 @@ resource "kubernetes_job" "migration" {
           dynamic "env" {
             for_each = local.database.tls.enabled ? [
               { name = "FLEET_MYSQL_TLS_CA", value = "/secrets/mysql/${local.database.tls.ca_cert_key}" },
-              { name = "FLEET_MYSQL_TLS_CERT", value = "/secrets/mysql/${local.database.tls.cert_secret_key}" },
+              { name = "FLEET_MYSQL_TLS_CERT", value = "/secrets/mysql/${local.database.tls.cert_key}" },
               { name = "FLEET_MYSQL_TLS_KEY", value = "/secrets/mysql/${local.database.tls.key_key}" },
               { name = "FLEET_MYSQL_TLS_CONFIG", value = local.database.tls.config },
               { name = "FLEET_MYSQL_TLS_SERVER_NAME", value = local.database.tls.server_name }
@@ -223,7 +223,7 @@ resource "kubernetes_job" "migration" {
           for_each = local.database.tls.enabled ? [
             {
               name        = "mysql-tls",
-              secret_name = local.database.tls.secret_name
+              secret_name = local.database.secret_name
             }
           ] : []
 


### PR DESCRIPTION
The database.tls input variable schema (k8s/variables.tf) declares six
attributes: enabled, config, server_name, ca_cert_key, cert_key, key_key.
However k8s/deploy.tf, k8s/job.tf, and k8s/cronjob.tf reference two
attributes that do not exist on that type:

  * local.database.tls.cert_secret_key  -> should be cert_key
  * local.database.tls.secret_name      -> not on tls; the MySQL secret
                                           is local.database.secret_name

These are inside dynamic blocks gated on local.database.tls.enabled,
but Terraform type-checks the expressions during planning regardless,
so any consumer setting database.tls.enabled = true (or even leaving
TLS off, since the type-check is static) hits:

  Error: Unsupported attribute
    This object does not have an attribute named "cert_secret_key".
  Error: Unsupported attribute
    This object does not have an attribute named "secret_name".

Align all three files with the variable schema, matching the pattern
already used for the password env var (which correctly reads
local.database.secret_name).