### PR TITLE
gcp: set cpu_idle=false on fleet-api Cloud Run service

### DIFF
--- a/gcp/byo-project/cloud_run.tf
+++ b/gcp/byo-project/cloud_run.tf
@@ -110,6 +110,12 @@ module "fleet-service" {
 
       resources = {
         limits = local.fleet_resources_limits
+        # CPU must remain allocated outside of request processing so Fleet's
+        # background cron goroutines (e.g. apple_mdm_dep_profile_assigner) can
+        # run reliably. Without this, the throttled CPU between requests
+        # cancels in-flight cron work mid-tick, which can silently drop DEP
+        # device events. See fleetdm/fleet-terraform#242 and fleetdm/fleet#46235.
+        cpu_idle = false
       }
 
       env_vars        = local.fleet_env_vars


### PR DESCRIPTION
## Summary

- The fleet-api Cloud Run service in `gcp/byo-project/cloud_run.tf` was running with the Cloud Run default of `cpu_idle = true` (CPU only allocated during request processing).
- This context-cancels Fleet's background cron goroutines between requests. In particular, `apple_mdm_dep_profile_assigner` can advance the nanodep sync cursor in `nano_dep_names.syncer_cursor` without committing the corresponding device upserts to `host_dep_assignments`, silently dropping DEP device events that Apple's DEP API will not re-emit. Only a manual cursor reset recovers.
- This PR sets `cpu_idle = false` on the container's `resources` block so the warm instance (already enforced by `min_instance_count = 1`) keeps CPU allocated for cron goroutines.

## Test plan

- [ ] `terraform plan` shows the change as an in-place update on the existing Cloud Run service (no replacement).
- [ ] After apply, `gcloud run services describe fleet-api --region <region> --format='yaml(spec.template.metadata.annotations)'` shows `run.googleapis.com/cpu-throttling: 'false'`.
- [ ] Tail logs and confirm `apple_mdm_dep_profile_assigner` `completed`s cleanly each tick with no `context canceled` / `unlock failed` / `update cron stats: context canceled` entries.
- [ ] Confirm no `pending job might still be running, wait 1m0s` stalls.

## Related

- Fixes #242
- Related: fleetdm/fleet#46235

🤖 Generated with [Claude Code](https://claude.com/claude-code)