### PR TITLE
gcp: support sidecar containers + addons/gcp/otel-sidecar

### DIFF
--- a/addons/gcp/otel-sidecar/README.md
+++ b/addons/gcp/otel-sidecar/README.md
@@ -1,0 +1,159 @@
+# GCP OpenTelemetry Sidecar — Cloud Run
+
+Wires Fleet's built-in OpenTelemetry SDK to a sidecar collector running alongside `fleet-api` on Cloud Run. Ships traces, metrics, and logs through whatever collector you mount (Datadog DDOT, the upstream OpenTelemetry Collector, Grafana Alloy, Honeycomb agent, ...).
+
+This addon emits **environment variables only**. You provide the sidecar container yourself via the GCP module's `sidecar_containers` input — examples below.
+
+## Why
+
+Fleet emits OTLP/gRPC for all three signal types (`otlptracegrpc`, `otlpmetricgrpc`, `otlploggrpc`). You can ship that data through any OTel-compatible backend by running a collector as a sidecar in the same Cloud Run instance and pointing Fleet at `localhost:4317`.
+
+Compared to Fleet's other observability paths:
+
+| Path | What it covers | Where it goes |
+| ---- | -------------- | ------------- |
+| `addons/logging-destination-*` | osquery scheduled query / status / activity audit logs | SaaS log backends |
+| **This addon** | **Fleet *server* traces, metrics, logs** (everything except osquery results) | Any OTel-compatible backend |
+| `addons/xrays-sidecar` | Fleet server traces (AWS-only) | AWS X-Ray |
+
+## Prerequisites
+
+The GCP module must accept multi-container Cloud Run services, which requires the upstream `GoogleCloudPlatform/cloud-run/google//modules/v2` module to support sidecars without a `ports` block. That fix is being tracked in [GoogleCloudPlatform/terraform-google-cloud-run#450](https://github.com/GoogleCloudPlatform/terraform-google-cloud-run/pull/450) — until it merges, attempting to deploy with `var.sidecar_containers` will fail with:
+
+```
+Error 400: Revision template should contain exactly one container with an exposed port.
+```
+
+Until upstream merges, you can vendor the patched module locally; this addon's outputs are unaffected by where the cloud-run module comes from.
+
+## Usage
+
+```hcl
+module "fleet_otel" {
+  source = "github.com/fleetdm/fleet-terraform//addons/gcp/otel-sidecar?ref=main"
+
+  service_name           = "fleet"
+  service_version        = "v4.85.0" # match var.fleet_config.image_tag
+  deployment_environment = "prod"
+
+  extra_resource_attributes = {
+    "team"   = "sre"
+    "region" = "us-central1"
+  }
+}
+
+module "fleet" {
+  source = "github.com/fleetdm/fleet-terraform//gcp?ref=main"
+  # ... other inputs ...
+
+  fleet_config = merge(var.fleet_config, {
+    extra_env_vars = merge(
+      coalesce(var.fleet_config.extra_env_vars, {}),
+      module.fleet_otel.fleet_extra_environment_variables.universal,
+    )
+  })
+
+  service_only_env_vars = module.fleet_otel.fleet_extra_environment_variables.service_only
+
+  sidecar_containers = [
+    # Pick one of the example sidecar definitions below.
+  ]
+}
+```
+
+The split between `universal` and `service_only` env vars exists because Fleet's migration job (a Cloud Run Job, not a Service) runs without sidecars. The `OTEL_EXPORTER_OTLP_ENDPOINT=http://localhost:4317` var would point to a non-existent listener during migrations, causing exporter retry noise in the job logs. Wire `universal` into `extra_env_vars` (visible to both) and `service_only` into `service_only_env_vars` (Service only).
+
+## Sidecar examples
+
+Each example is a single object you drop into `module.fleet.sidecar_containers = [ ... ]`. Cloud Run requires:
+
+1. Every sidecar declared in another container's `depends_on_container` must have its own `startup_probe`. The probe targets the OTLP gRPC port — once it accepts connections, the collector is ready.
+2. Only one container per service may own the ingress port. Set `ports = { name = "", container_port = 0 }` on sidecars to opt out (sentinel honored by the cloud-run v2 module once [PR #450](https://github.com/GoogleCloudPlatform/terraform-google-cloud-run/pull/450) lands).
+
+### OpenTelemetry Collector (contrib) — vendor-neutral
+
+```hcl
+sidecar_containers = [
+  {
+    container_name  = "otel-collector"
+    container_image = "otel/opentelemetry-collector-contrib:latest"
+    container_args  = ["--config=/etc/otelcol/config.yaml"]
+
+    # You need to mount a config.yaml. Store it as a Secret Manager secret
+    # and mount via volume_mounts. See addons/gcp/otel-sidecar/examples/
+    # for a config that exports to Datadog, Honeycomb, or Grafana Cloud.
+    volume_mounts = [{
+      name       = "otel-config"
+      mount_path = "/etc/otelcol"
+    }]
+
+    resources = {
+      limits = { cpu = "500m", memory = "256Mi" }
+    }
+    ports = { name = "", container_port = 0 }
+    startup_probe = {
+      tcp_socket            = { port = 4317 }
+      initial_delay_seconds = 5
+      period_seconds        = 5
+      timeout_seconds       = 2
+      failure_threshold     = 30
+    }
+  }
+]
+```
+
+### Datadog DDOT collector — Datadog backend
+
+DDOT is the Datadog Agent in OTel-collector mode (`DD_OTELCOLLECTOR_ENABLED=true`). Documented for Linux, Kubernetes, and EKS Fargate; the Cloud Run install path isn't covered by Datadog docs but works in practice (verified production usage shipping all three signal types to us5).
+
+Use `agent:latest-full`, not `agent:latest` — the `-full` variant bundles the DDOT subprocess.
+
+```hcl
+sidecar_containers = [
+  {
+    container_name  = "datadog-agent"
+    container_image = "gcr.io/datadoghq/agent:latest-full"
+
+    env_vars = {
+      DD_SITE                  = "us5.datadoghq.com"  # or datadoghq.com, datadoghq.eu, etc.
+      DD_SERVICE               = "fleet"
+      DD_ENV                   = "prod"
+      DD_VERSION               = "v4.85.0"
+      DD_OTELCOLLECTOR_ENABLED = "true"
+      DD_LOGS_ENABLED          = "true"
+      DD_HOSTNAME              = "fleet-api-cloudrun"  # Cloud Run instances are ephemeral; pin to a logical hostname
+    }
+    env_secret_vars = {
+      DD_API_KEY = {
+        secret  = google_secret_manager_secret.datadog_api_key.secret_id
+        version = "latest"
+      }
+    }
+
+    resources = {
+      limits = { cpu = "1", memory = "512Mi" }
+    }
+    ports = { name = "", container_port = 0 }
+    startup_probe = {
+      tcp_socket            = { port = 4317 }
+      initial_delay_seconds = 5
+      period_seconds        = 5
+      timeout_seconds       = 2
+      failure_threshold     = 30
+    }
+  }
+]
+```
+
+Set `enable_otel_logs = false` on this addon if you're using `gcr.io/datadoghq/serverless-init` instead — its OTLP logs pipeline is broken ([datadog-agent#34097](https://github.com/DataDog/datadog-agent/issues/34097)). DDOT's is fine.
+
+### Grafana Alloy — Grafana Cloud / self-hosted Grafana stack
+
+Similar pattern: image is `grafana/alloy:latest`, args point at a config file mounted via `volume_mounts`. Config follows the Alloy "river" config format with an `otelcol.receiver.otlp` block.
+
+## Notes
+
+- Fleet sets `OTEL_SERVICE_NAME=fleet` internally via `semconv.ServiceName("fleet")`. We set it again in the env var so callers can override.
+- The Go OTel SDK defaults to TLS for OTLP gRPC. Talking plaintext to a localhost sidecar requires `OTEL_EXPORTER_OTLP_INSECURE=true` (this addon sets it).
+- `FLEET_LOGGING_OTEL_LOGS_ENABLED=true` requires `FLEET_LOGGING_TRACING_ENABLED=true` (Fleet validates this on startup — see `cmd/fleet/serve.go`).
+- The migration job runs only once per `image_tag` change. Even without the env-var split, the noise window is brief, but the split is correct hygiene.

--- a/addons/gcp/otel-sidecar/main.tf
+++ b/addons/gcp/otel-sidecar/main.tf
@@ -1,0 +1,18 @@
+# This addon outputs the Fleet env vars needed to enable OpenTelemetry export
+# to an OTLP gRPC receiver on localhost:4317. It does not provision a sidecar
+# container itself — callers wire their preferred collector (DDOT,
+# otelcol-contrib, Grafana Alloy, Honeycomb agent, ...) via the gcp module's
+# var.sidecar_containers input.
+#
+# See the README for example sidecar definitions.
+
+locals {
+  resource_attributes = join(",", concat(
+    [
+      "service.name=${var.service_name}",
+      "deployment.environment=${var.deployment_environment}",
+    ],
+    var.service_version != null ? ["service.version=${var.service_version}"] : [],
+    [for k, v in var.extra_resource_attributes : "${k}=${v}"],
+  ))
+}

--- a/addons/gcp/otel-sidecar/outputs.tf
+++ b/addons/gcp/otel-sidecar/outputs.tf
@@ -1,0 +1,22 @@
+output "fleet_extra_environment_variables" {
+  description = "Env vars to pass to module.fleet.fleet_config.extra_env_vars (for the migration job) and var.service_only_env_vars (for the Cloud Run service). The OTLP endpoint var is service-only since the migration job runs without sidecars."
+  value = {
+    # Universal across job + service: enables Fleet's OTel SDK init. Safe
+    # because if no collector is reachable, the SDK silently retries with
+    # exponential backoff — no Fleet-side error.
+    universal = {
+      FLEET_LOGGING_TRACING_ENABLED   = "true"
+      FLEET_LOGGING_OTEL_LOGS_ENABLED = var.enable_otel_logs ? "true" : "false"
+      OTEL_SERVICE_NAME               = var.service_name
+      OTEL_RESOURCE_ATTRIBUTES        = local.resource_attributes
+    }
+    # Service-only: depends on a sidecar listening at this address. The
+    # migration job runs without sidecars, so it must not see these.
+    service_only = {
+      OTEL_EXPORTER_OTLP_ENDPOINT = var.otlp_endpoint
+      OTEL_EXPORTER_OTLP_PROTOCOL = "grpc"
+      # The Go OTel SDK defaults to TLS; localhost is plaintext.
+      OTEL_EXPORTER_OTLP_INSECURE = "true"
+    }
+  }
+}

--- a/addons/gcp/otel-sidecar/variables.tf
+++ b/addons/gcp/otel-sidecar/variables.tf
@@ -1,0 +1,35 @@
+variable "service_name" {
+  description = "OTel service.name resource attribute. Surfaces in backends as the service tag/dimension."
+  type        = string
+  default     = "fleet"
+}
+
+variable "service_version" {
+  description = "OTel service.version resource attribute. Recommended: set to the Fleet image tag (e.g. \"v4.85.0\") so per-release attribution works in the backend."
+  type        = string
+  default     = null
+}
+
+variable "deployment_environment" {
+  description = "OTel deployment.environment resource attribute (e.g. \"prod\", \"staging\")."
+  type        = string
+  default     = "prod"
+}
+
+variable "extra_resource_attributes" {
+  description = "Additional OTel resource attributes merged into OTEL_RESOURCE_ATTRIBUTES. Useful for custom tags like {team = \"sre\", region = \"us-central1\"}."
+  type        = map(string)
+  default     = {}
+}
+
+variable "otlp_endpoint" {
+  description = "OTLP gRPC endpoint Fleet's OTel SDK exporters target. Defaults to the localhost sidecar pattern; override only if you're routing through a different listener (e.g. a Unix socket or an inline DDOT subprocess port)."
+  type        = string
+  default     = "http://localhost:4317"
+}
+
+variable "enable_otel_logs" {
+  description = "Enable Fleet's OTel logs exporter (FLEET_LOGGING_OTEL_LOGS_ENABLED). Logs ship to the same OTLP endpoint as traces and metrics. Set to false if your collector doesn't accept OTLP logs (notably gcr.io/datadoghq/serverless-init — see datadog-agent#34097)."
+  type        = bool
+  default     = true
+}

--- a/addons/gcp/otel-sidecar/versions.tf
+++ b/addons/gcp/otel-sidecar/versions.tf
@@ -1,0 +1,3 @@
+terraform {
+  required_version = ">= 1.5"
+}

--- a/gcp/byo-project/cloud_run.tf
+++ b/gcp/byo-project/cloud_run.tf
@@ -37,9 +37,18 @@ locals {
     FLEET_S3_SOFTWARE_INSTALLERS_REGION              = var.region
   })
 
+  # fleet_env_vars is the safe baseline that works in any execution context.
+  # The migration job (Cloud Run Job, no sidecars) uses it directly. The
+  # Cloud Run service layers var.service_only_env_vars on top — that's where
+  # things like OTel exporter endpoints live, since the job can't reach a
+  # localhost OTLP receiver that only exists in the service context.
+  fleet_service_env_vars = merge(local.fleet_env_vars, var.service_only_env_vars)
+
   fleet_vpc_network_id = module.vpc.network_id
   # Use the direct construction for the subnet ID key as discussed
   fleet_vpc_subnet_id = "fleet-subnet"
+
+  sidecar_container_names = [for c in var.sidecar_containers : c.container_name]
 }
 
 module "fleet-service" {
@@ -73,9 +82,11 @@ module "fleet-service" {
     max_instance_count = var.fleet_config.max_instance_count
   }
 
-  containers = [
+  containers = concat([
     {
-      container_image = local.fleet_image_tag
+      container_name       = "fleet"
+      container_image      = local.fleet_image_tag
+      depends_on_container = local.sidecar_container_names
       ports = {
         name           = var.fleet_config.use_h2c ? "h2c" : "http1"
         container_port = 8080
@@ -112,10 +123,10 @@ module "fleet-service" {
         limits = local.fleet_resources_limits
       }
 
-      env_vars        = local.fleet_env_vars
+      env_vars        = local.fleet_service_env_vars
       env_secret_vars = local.fleet_secrets_env_vars
     }
-  ]
+  ], var.sidecar_containers)
 }
 
 # --- Cloud Run Job (Migrations) ---

--- a/gcp/byo-project/iam.tf
+++ b/gcp/byo-project/iam.tf
@@ -48,3 +48,18 @@ resource "google_secret_manager_secret_iam_member" "fleet_run_sa_private_key_sec
   depends_on = [google_secret_manager_secret.private_key]
 }
 
+# Sidecar containers may reference their own secrets (e.g. an observability
+# agent's API key). The Cloud Run SA runs every container in the service, so
+# it needs accessor on each sidecar secret too. Iterating var.sidecar_containers
+# keeps this grant in sync with whatever sidecars callers wire in.
+resource "google_secret_manager_secret_iam_member" "fleet_run_sa_sidecar_secret_access" {
+  for_each = merge([
+    for c in var.sidecar_containers : c.env_secret_vars
+  ]...)
+
+  project   = var.project_id
+  secret_id = each.value.secret
+  role      = "roles/secretmanager.secretAccessor"
+  member    = "serviceAccount:${google_service_account.fleet_run_sa.email}"
+}
+

--- a/gcp/byo-project/variables.tf
+++ b/gcp/byo-project/variables.tf
@@ -88,6 +88,75 @@ variable "vpc_config" {
   }
 
 }
+
+variable "sidecar_containers" {
+  description = <<-EOT
+    Optional sidecar containers to run alongside Fleet in the fleet-api Cloud
+    Run service. Shape matches the cloud-run module's container object.
+
+    Useful for OpenTelemetry collectors (otelcol-contrib, Datadog DDOT, Grafana
+    Alloy, etc.) that expose an OTLP receiver Fleet can ship traces, metrics,
+    and logs into via its built-in OTel SDK exporters.
+
+    Requirements imposed by Cloud Run:
+
+      - Each sidecar must declare a startup_probe. Cloud Run rejects any
+        depends_on reference to a container without one.
+      - Only one container per service may own the ingress port. Set
+        ports = { name = "", container_port = 0 } on sidecars to opt out
+        (requires the cloud-run v2 module to accept container_port = 0 as a
+        "no exposed port" sentinel — see
+        https://github.com/GoogleCloudPlatform/terraform-google-cloud-run/pull/450).
+  EOT
+  type = list(object({
+    container_name       = string
+    container_image      = string
+    container_args       = optional(list(string))
+    container_command    = optional(list(string))
+    depends_on_container = optional(list(string))
+    env_vars             = optional(map(string), {})
+    env_secret_vars = optional(map(object({
+      secret  = string
+      version = string
+    })), {})
+    ports = optional(object({
+      name           = optional(string)
+      container_port = optional(number)
+    }))
+    resources = optional(object({
+      limits = optional(object({
+        cpu    = optional(string)
+        memory = optional(string)
+      }))
+      cpu_idle          = optional(bool, true)
+      startup_cpu_boost = optional(bool, false)
+    }), {})
+    startup_probe = optional(object({
+      failure_threshold     = optional(number)
+      initial_delay_seconds = optional(number)
+      timeout_seconds       = optional(number)
+      period_seconds        = optional(number)
+      tcp_socket = optional(object({
+        port = optional(number)
+      }))
+    }))
+  }))
+  default = []
+}
+
+variable "service_only_env_vars" {
+  description = <<-EOT
+    Extra env vars applied only to the fleet-api Cloud Run service, not the
+    migration job. Use this for vars that depend on a sidecar container being
+    present, such as OTEL_EXPORTER_OTLP_ENDPOINT=http://localhost:4317 — the
+    migration job runs as a Cloud Run Job with no sidecars, so localhost:4317
+    has no listener and the OTel exporter would log retry errors during the
+    brief job run.
+  EOT
+  type        = map(string)
+  default     = {}
+}
+
 variable "fleet_config" {
   type = object({
     installers_bucket_name = string

--- a/gcp/main.tf
+++ b/gcp/main.tf
@@ -50,14 +50,16 @@ module "project_factory" {
 }
 
 module "fleet" {
-  source          = "./byo-project"
-  project_id      = module.project_factory.project_id
-  dns_record_name = var.dns_record_name
-  dns_zone_name   = var.dns_zone_name
-  vpc_config      = var.vpc_config
-  fleet_config    = var.fleet_config
-  cache_config    = var.cache_config
-  database_config = var.database_config
-  region          = var.region
-  location        = var.location
+  source                = "./byo-project"
+  project_id            = module.project_factory.project_id
+  dns_record_name       = var.dns_record_name
+  dns_zone_name         = var.dns_zone_name
+  vpc_config            = var.vpc_config
+  fleet_config          = var.fleet_config
+  cache_config          = var.cache_config
+  database_config       = var.database_config
+  region                = var.region
+  location              = var.location
+  sidecar_containers    = var.sidecar_containers
+  service_only_env_vars = var.service_only_env_vars
 }

--- a/gcp/variables.tf
+++ b/gcp/variables.tf
@@ -150,3 +150,15 @@ variable "fleet_config" {
     extra_secret_env_vars  = {}
   }
 }
+
+variable "sidecar_containers" {
+  description = "Optional sidecar containers to run alongside Fleet in the fleet-api Cloud Run service. See byo-project/variables.tf for the full schema and addons/gcp/otel-sidecar/README.md for example collector configs."
+  type        = any
+  default     = []
+}
+
+variable "service_only_env_vars" {
+  description = "Extra env vars applied only to the fleet-api Cloud Run service, not the migration job. Use for vars that depend on a sidecar (e.g. OTEL_EXPORTER_OTLP_ENDPOINT)."
+  type        = map(string)
+  default     = {}
+}


### PR DESCRIPTION
## Summary

Adds two inputs to the `gcp` module so callers can colocate sidecars (typically OpenTelemetry collectors) with the `fleet-api` Cloud Run service, plus a new `addons/gcp/otel-sidecar` addon that emits the matching Fleet env vars.

- **`var.sidecar_containers`** (list of container objects) — wires arbitrary sidecars into the Cloud Run service. Matches the upstream cloud-run module's container schema. Useful for any collector exposing an OTLP receiver on a localhost port (Datadog DDOT, otelcol-contrib, Grafana Alloy, Honeycomb agent, …).
- **`var.service_only_env_vars`** (map) — env vars applied to the Cloud Run service but not the migration job. Needed for vars that depend on a sidecar being present, e.g. `OTEL_EXPORTER_OTLP_ENDPOINT=http://localhost:4317` — the migration job (a Cloud Run Job) has no sidecars, so it would log exporter retry noise during each migration if those vars leaked in.
- **`addons/gcp/otel-sidecar/`** — emits the `FLEET_LOGGING_TRACING_ENABLED`, `FLEET_LOGGING_OTEL_LOGS_ENABLED`, `OTEL_EXPORTER_OTLP_*`, and `OTEL_RESOURCE_ATTRIBUTES` env vars in a `{universal, service_only}` split so callers route them correctly. Doesn't ship a sidecar container itself — the README has copy-pasteable examples for OpenTelemetry Collector contrib and Datadog DDOT.

Follows the `addons/gcp/*` convention established by #223 (`okta-conditional-access`) and #231 (`pubsub-to-bigquery`).

## Why

Fleet's server has built-in OpenTelemetry exporters for traces, metrics, and logs (`otlptracegrpc`, `otlpmetricgrpc`, `otlploggrpc` — all gRPC). The pattern that actually works on Cloud Run is: run an OTel collector as a sidecar in the same instance, point Fleet at `localhost:4317`, let the collector forward to whatever backend.

Today the `gcp` module only renders a single container per service, so there's no clean way to express this. Direct OTLP intake from Fleet to a SaaS backend isn't a workable substitute — Datadog's direct intake is HTTP-only and requires delta temporality, neither of which Fleet supports without source patches.

Comparable prior art: [`addons/xrays-sidecar`](https://github.com/fleetdm/fleet-terraform/tree/main/addons/xrays-sidecar) does the same job for AWS X-Ray on ECS. This PR fills the GCP gap.

## Backwards compatibility

Both new inputs default to empty (`[]` and `{}`). With defaults, the rendered output is functionally identical to today — only field added is `container_name = "fleet"` on the main container (forces one revision swap on first deploy after upgrade, no behavior change).

The migration job is untouched. The `fleet-service` Cloud Run service gets the new container name + a `depends_on` only when callers actually pass sidecars.

## Prerequisite

Multi-container Cloud Run services require [`GoogleCloudPlatform/terraform-google-cloud-run#450`](https://github.com/GoogleCloudPlatform/terraform-google-cloud-run/pull/450) (open, mergeable, awaiting maintainer review) to land. That PR fixes a `lookup() != {}` skip in the v2 module's `dynamic "ports"` block that prevents sidecars from opting out of the ingress port. Until it merges, attempting `terraform apply` with non-empty `sidecar_containers` fails with:

```
Error 400: Revision template should contain exactly one container with an exposed port.
```

I've called this out clearly in the addon README and the `var.sidecar_containers` description. Callers can vendor the patched module locally as a workaround — that's how the production deployment this PR is extracted from runs today.

This PR is fine to merge before #450; the new inputs default to empty so nothing breaks for existing users, and the new code path becomes useful once #450 ships.

## Validation

- `terraform fmt -recursive` + `terraform validate` clean for both `gcp/` and `addons/gcp/otel-sidecar/`.
- The runtime behavior — Fleet's OTel SDK shipping traces, metrics, and logs through a DDOT sidecar (`gcr.io/datadoghq/agent:latest-full` + `DD_OTELCOLLECTOR_ENABLED=true`) to Datadog us5 — is live in production at Campus today, on both a primary `fleet-api` service and a secondary bulk service. Verified all three signal types land in Datadog APM Traces, Metrics Explorer, and Log Explorer.

## Test plan

- [ ] On a clean GCP project, set `sidecar_containers = []` and `service_only_env_vars = {}` → confirm no infrastructure change from current `main`.
- [ ] After GoogleCloudPlatform/terraform-google-cloud-run#450 lands, add a sidecar per the addon README's "OpenTelemetry Collector (contrib)" example → confirm Fleet's `/healthz` stays passing and OTel data reaches the collector (e.g. via the `debug` exporter).
- [ ] Confirm the migration job (Cloud Run Job) does not receive `OTEL_EXPORTER_OTLP_ENDPOINT` after wiring `service_only_env_vars`.