### PR TITLE
Add rds_config.deletion_protection passthrough to the Aurora cluster

### DIFF
--- a/byo-vpc/main.tf
+++ b/byo-vpc/main.tf
@@ -890,6 +890,7 @@ module "rds" {
   final_snapshot_identifier       = local.rds_final_snapshot_identifiers[each.key]
   snapshot_identifier             = each.value.snapshot_identifier
   backup_retention_period         = each.value.backup_retention_period
+  deletion_protection             = each.value.deletion_protection
   restore_to_point_in_time        = each.value.restore_to_point_in_time
 
   preferred_maintenance_window = each.value.preferred_maintenance_window

--- a/byo-vpc/variables.tf
+++ b/byo-vpc/variables.tf
@@ -123,6 +123,7 @@ variable "rds_config" {
     preferred_maintenance_window = optional(string, "thu:23:00-fri:00:00")
     skip_final_snapshot          = optional(bool, true)
     backup_retention_period      = optional(number, 7)
+    deletion_protection          = optional(bool, null)
     replicas                     = optional(number, 2)
     serverless                   = optional(bool, false)
     serverless_min_capacity      = optional(number, 2)
@@ -185,6 +186,7 @@ variable "rds_config" {
     preferred_maintenance_window = "thu:23:00-fri:00:00"
     skip_final_snapshot          = true
     backup_retention_period      = 7
+    deletion_protection          = null
     replicas                     = 2
     serverless                   = false
     serverless_min_capacity      = 2
@@ -316,6 +318,7 @@ variable "rds_configs" {
     preferred_maintenance_window = optional(string, "thu:23:00-fri:00:00")
     skip_final_snapshot          = optional(bool, true)
     backup_retention_period      = optional(number, 7)
+    deletion_protection          = optional(bool, null)
     replicas                     = optional(number, 2)
     serverless                   = optional(bool, false)
     serverless_min_capacity      = optional(number, 2)

--- a/variables.tf
+++ b/variables.tf
@@ -289,6 +289,7 @@ variable "rds_config" {
     preferred_maintenance_window = optional(string, "thu:23:00-fri:00:00")
     skip_final_snapshot          = optional(bool, true)
     backup_retention_period      = optional(number, 7)
+    deletion_protection          = optional(bool, null)
     replicas                     = optional(number, 2)
     serverless                   = optional(bool, false)
     serverless_min_capacity      = optional(number, 2)
@@ -351,6 +352,7 @@ variable "rds_config" {
     preferred_maintenance_window = "thu:23:00-fri:00:00"
     skip_final_snapshot          = true
     backup_retention_period      = 7
+    deletion_protection          = null
     replicas                     = 2
     serverless                   = false
     serverless_min_capacity      = 2
@@ -482,6 +484,7 @@ variable "rds_configs" {
     preferred_maintenance_window = optional(string, "thu:23:00-fri:00:00")
     skip_final_snapshot          = optional(bool, true)
     backup_retention_period      = optional(number, 7)
+    deletion_protection          = optional(bool, null)
     replicas                     = optional(number, 2)
     serverless                   = optional(bool, false)
     serverless_min_capacity      = optional(number, 2)


### PR DESCRIPTION
## Summary

`aws_rds_cluster.deletion_protection` currently cannot be set through the root module or `byo-vpc`: the inner `terraform-aws-modules/rds-aurora` call does not receive it, so its `null` default always applies. Anyone who enables deletion protection on the cluster out-of-band then sees a permanent `deletion_protection: true -> false` diff on every plan, and an apply silently disables the protection.

This adds an optional `rds_config.deletion_protection` (default `null`) in the root module and `byo-vpc`, passed through to the aurora module. The default preserves current behavior exactly.

Happy to regenerate READMEs / adjust module version tags to match your release process.